### PR TITLE
Make permissions unique per domain, method, and granter

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,10 +3,7 @@
     "parserOptions": {
         "ecmaVersion": 6,
         "sourceType": "module",
-        "ecmaFeatures": {
-          "arrowFunctions": true
-        }
-    },
-    "env": { "es6": true }
+        "ecmaFeatures": {}
+    }
 }
 

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,10 @@
     "parserOptions": {
         "ecmaVersion": 6,
         "sourceType": "module",
-        "ecmaFeatures": {}
-    }
+        "ecmaFeatures": {
+          "arrowFunctions": true
+        }
+    },
+    "env": { "es6": true }
 }
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ const capabilities = createCapabilities({
         end()
       }
     },
-
   },
 
   /**
@@ -81,7 +80,6 @@ const capabilities = createCapabilities({
       }
     }
   }
-
 })
 
 // Unlike normal json-rpc-engine middleware, these methods all require

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ const capabilities = createCapabilities({
 
   },
 
-  /*
+  /**
   * A promise-returning callback used to determine whether to approve
   * permissions requests or not.
   *
@@ -72,11 +72,12 @@ const capabilities = createCapabilities({
   initState: {
     domains: {
       'login.metamask.io': {
-        permissions: {
-          'eth_write': {
+        permissions: [
+          {
+            method: 'eth_write',
             date: '0',
           }
-        }
+        ]
       }
     }
   }
@@ -106,11 +107,13 @@ The capabilities system adds new methods to the RPC, and you can modify what the
 ### Permissions Object
 
 ```
-'restrictedMethodName': {
+{
+  id: '63b225d0-414e-4a2d-8067-c34499c984c7', // uuid string
+  method: 'restrictedMethodName'
   date: 0, // unix time of creation
-  grantedBy: 'another.domain.com', // another domain string if this permission was created by delegation.
+  granter: 'another.domain.com', // another domain string if this permission was created by delegation.
   caveats: { // An optional object describing limitations on the method reference.
-    onlyStatic: 'Always this!', // The onlyStatic caveat only returns the specified static response.
+    static: 'Always this!', // The static caveat only returns the specified static response.
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -110,8 +110,11 @@ The capabilities system adds new methods to the RPC, and you can modify what the
   id: '63b225d0-414e-4a2d-8067-c34499c984c7', // UUID string
   date: 0, // unix time of creation
   granter: 'another.domain.com', // Another domain string if this permission was created by delegation.
-  caveats: [ // An optional object describing limitations on the method reference.
-    static: 'Always this!', // The static caveat only returns the specified static response.
+  caveats: [ // An optional array of objects describing limitations on the method reference.
+    {
+      type: 'static', // The static caveat only returns the specified static response value.
+      value: 'Always this!'
+    }
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -106,13 +106,13 @@ The capabilities system adds new methods to the RPC, and you can modify what the
 
 ```
 {
-  id: '63b225d0-414e-4a2d-8067-c34499c984c7', // uuid string
-  method: 'restrictedMethodName'
+  method: 'restrictedMethodName',
+  id: '63b225d0-414e-4a2d-8067-c34499c984c7', // UUID string
   date: 0, // unix time of creation
-  granter: 'another.domain.com', // another domain string if this permission was created by delegation.
-  caveats: { // An optional object describing limitations on the method reference.
+  granter: 'another.domain.com', // Another domain string if this permission was created by delegation.
+  caveats: [ // An optional object describing limitations on the method reference.
     static: 'Always this!', // The static caveat only returns the specified static response.
-  }
+  ]
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 const ObservableStore = require('obs-store');
 const equal = require('fast-deep-equal');
-const clone = require('clone');
-const generateRandomString = require('crypto-random-string');
+const uuid = require('uuid/v4');
 
 
 const UNAUTHORIZED_ERROR = {
@@ -19,7 +18,10 @@ const USER_REJECTED_ERROR = {
   message: 'User rejected the request.',
 };
 
-function createJsonRpcCapabilities ({ safeMethods = [], restrictedMethods = {}, initState = {}, methods = {}, methodPrefix = '', requestUserApproval}) {
+function createJsonRpcCapabilities ({
+  safeMethods = [], restrictedMethods = {}, initState = {},
+  methods = {}, methodPrefix = '', requestUserApproval
+}) {
 
   const that = {};
 
@@ -43,7 +45,7 @@ function createJsonRpcCapabilities ({ safeMethods = [], restrictedMethods = {}, 
     return that.store.getState();
   };
 
-  /*
+  /**
    * Returns a nearly json-rpc-engine compatible method.
    * The one difference being the first argument should be
    * a unique string identifying the requesting agent/entity,
@@ -119,23 +121,30 @@ function createJsonRpcCapabilities ({ safeMethods = [], restrictedMethods = {}, 
       const { permissions } = domains[domain];
       return permissions;
     }
-    return {};
+    return [];
   };
 
-  /*
+  /**
    * Get the parent-most permission granting the requested domain's method permission.
+   * Follows the granter chain of the first matching permission found.
    */
   function getPermission (domain, method) {
     // TODO: Aggregate & Enforce Caveats at each step.
     // https://w3c-ccg.github.io/ocap-ld/#caveats
 
-    let permissions = that.getPermissionsForDomain(domain);
+    let perm;
+    let permissions = that.getPermissionsForDomain(domain).filter(
+      p => p.method === method
+    );
 
-    while (permissions && Object.keys(permissions).includes(method)) {
-      if (Object.keys(permissions[method]).includes('grantedBy')) {
-        permissions = that.getPermissionsForDomain(permissions[method].grantedBy);
+    while (permissions.length > 0) {
+      perm = permissions.shift();
+      if (perm.granter) {
+        permissions = that.getPermissionsForDomain(perm.granter).filter(
+          p => p.method === method
+        );
       } else {
-        return permissions[method];
+        return perm;
       }
     }
 
@@ -143,46 +152,60 @@ function createJsonRpcCapabilities ({ safeMethods = [], restrictedMethods = {}, 
   };
   that.getPermission = getPermission;
 
-  /*
-   * Get the permission for that domain and method, not following grantedBy links.
+  /**
+   * Get the permission for that domain and method, not following granter links.
+   * Returns the first such permission found.
    */
-  that.getPermissionUnTraversed = function (domain, method) {
+  that.getPermissionUnTraversed = function (domain, method, granter = undefined) {
     // TODO: Aggregate & Enforce Caveats at each step.
     // https://w3c-ccg.github.io/ocap-ld/#caveats
 
-    let permissions = that.getPermissionsForDomain(domain);
-    if (permissions && Object.keys(permissions).includes(method)) {
-      return permissions[method];
-    }
+    let permissions = that.getPermissionsForDomain(domain).filter(p => {
+      let out = p.method === method;
+      if (granter !== undefined) {
+        out = out && p.granter === granter;
+      }
+      return out;
+    });
+    if (permissions.length > 0) { return permissions.shift(); }
 
     return undefined;
   };
 
   that.getPermissions = function () {
     const perms = that.memStore.getState().permissions;
-    return perms || {};
+    return perms || [];
   };
 
   that.getPermissionsRequests = function () {
     const reqs = that.memStore.getState().permissionsRequests;
-    return reqs || {};
+    return reqs || [];
   };
 
   that.setPermissionsRequests = function (permissionsRequests) {
     that.memStore.updateState({ permissionsRequests });
   };
 
-  /*
+  /**
    * Used for granting a new set of permissions,
    * after the user has approved it.
-   *
-   * @param {object} permissions - An object describing the granted permissions.
+   * 
+   * @param {string} domain - The domain receiving new permissions.
+   * @param {Array} permissions - An array of objects describing the granted permissions.
+   * @param {Object} res - The response.
+   * @param {function} end - The end function.
    */
   that.grantNewPermissions = function (domain, permissions, res, end) {
     // Remove any matching requests from the queue:
     that.setPermissionsRequests(that.getPermissionsRequests().filter((request) => {
       const sameDomain = request.origin === domain;
-      const samePerms = equal(Object.keys(request.options), Object.keys(permissions));
+      let samePerms = false;
+      for (let perm of permissions) {
+        if (perm.method === request.options.method) {
+          samePerms = true;
+          break;
+        }
+      }
       return !(sameDomain && samePerms);
     }));
 
@@ -202,47 +225,91 @@ function createJsonRpcCapabilities ({ safeMethods = [], restrictedMethods = {}, 
   };
 
   that.getDomainSettings = function (domain) {
-    const domains = that.getDomains;
+    const domains = that.getDomains();
 
     // Setup if not yet existent:
     if (!(Object.keys(domains).includes(domain))) {
-      domains[domain] = { permissions: {} };
+      domains[domain] = { permissions: [] };
     }
 
     return domains[domain];
   };
 
   that.setDomain = function (domain, domainSettings) {
-    const domains = that.getDomains;
+    const domains = that.getDomains();
     domains[domain] = domainSettings;
     const state = that.store.getState();
     state.domains = domains;
     that.store.putState(state);
   };
 
+  /**
+   * Sets permissions for the given domain. Removes existing identical
+   * permissions (same domain, method, and granter).
+   * 
+   * @param {string} domainName - The grantee domain.
+   * @param {Array} newPermissions - The new permissions for the grantee domain.
+   */
   that.setPermissionsFor = function (domainName, newPermissions) {
     const domain = that.getDomainSettings(domainName);
 
-    const { permissions } = domain;
-
-    Object.keys(newPermissions).forEach(function (key) {
-      permissions[key] = newPermissions[key];
+    /**
+     * TODO:F
+     * permissions are effectively overwritten here
+     * is this what we want to do? what about caveats?
+     * should caveats be explicitly defined each time a permission is defined?
+     */
+    // remove old permissions that will be overwritten
+    domain.permissions = domain.permissions.filter(oldPerm => {
+      let isReplaced = false;
+      for (newPerm of newPermissions) {
+        if (
+          oldPerm.method === newPerm.method &&
+          oldPerm.granter === newPerm.granter
+        ) {
+          isReplaced = true;
+          break;
+        }
+      }
+      return !isReplaced;
     });
 
-    domain.permissions = permissions;
+    // add new permissions
+    // TODO: ensure newPermissions only contains unique permissions
+    for (let perm of newPermissions) {
+      if (!perm.id) {
+        perm.id = uuid();
+        perm.date = Date.now();
+      }
+      domain.permissions.push(perm);
+    }
     that.setDomain(domainName, domain);
   };
 
+  /**
+   * Removes the specified permissions from the given domain.
+   * 
+   * @param {string} domainName - The domain name whose permissions to remove.
+   * @param {Array} permissionsToRemove - Objects identifying the permissions to remove.
+   */
   that.removePermissionsFor = function (domainName , permissionsToRemove) {
     const domain = that.getDomainSettings(domainName);
 
-    const { permissions } = domain;
+    domain.permissions = domain.permissions.reduce((acc, perm) => {
+      let keep = true;
+      for (let r of permissionsToRemove) {
+        if (
+          r.method === perm.method &&
+          r.granter === perm.granter
+        ) {
+          keep = false;
+          break;
+        }
+      }
+      if (keep) { acc.push(perm); }
+      return acc;
+    }, []);
 
-    permissionsToRemove.forEach((key) => {
-      delete permissions[key];
-    });
-
-    domain.permissions = permissions;
     that.setDomain(domainName, domain);
   };
 
@@ -252,12 +319,12 @@ function createJsonRpcCapabilities ({ safeMethods = [], restrictedMethods = {}, 
     end();
   };
 
-  /*
+  /**
    * The capabilities middleware function used for requesting additional permissions from the user.
    *
-   * @param {object} req - The JSON RPC formatted request object.
+   * @param {Object} req - The JSON RPC formatted request object.
    * @param {Array} req.params - The JSON RPC formatted params array.
-   * @param {object} req.params[0] - An object of the requested permissions.
+   * @param {Object} req.params[0] - An object of the requested permissions.
    */
   that.requestPermissionsMiddleware = function (domain, req, res, next, end) {
     const metadata = req.metadata || {
@@ -266,17 +333,19 @@ function createJsonRpcCapabilities ({ safeMethods = [], restrictedMethods = {}, 
     };
 
     if (!metadata.id) {
-      metadata.id = generateRandomString(16)
+      metadata.id = uuid();
     }
 
     // TODO: Validate permissions request
-    const options = req.params[0];
+    const permissions = req.params[0];
     const requests = that.getPermissionsRequests();
-    requests.push({
-      origin: domain,
-      metadata,
-      options,
-    });
+    for (let perm of permissions) {
+      requests.push({
+        origin: domain,
+        metadata,
+        options: perm,
+      });
+    }
     that.setPermissionsRequests(requests);
 
     if (!that.requestUserApproval) {
@@ -284,7 +353,7 @@ function createJsonRpcCapabilities ({ safeMethods = [], restrictedMethods = {}, 
       return end();
     }
 
-    that.requestUserApproval(metadata, options)
+    that.requestUserApproval(metadata, permissions)
     // TODO: Allow user to pass back an object describing
     // the approved permissions, allowing user-customization.
     .then((approved) => {
@@ -296,11 +365,11 @@ function createJsonRpcCapabilities ({ safeMethods = [], restrictedMethods = {}, 
 
       // If user approval is boolean, the request is wholly approved
       if (typeof approved === 'boolean') {
-        return that.grantNewPermissions(domain, options, res, end);
+        return that.grantNewPermissions(domain, permissions, res, end);
       }
 
       // If user approval is different, use it as the permissions:
-      that.grantNewPermissions(domain, approved, res, end);
+      that.grantNewPermissions(domain, [approved], res, end);
     })
     .catch((reason) => {
       res.error = reason;
@@ -308,23 +377,25 @@ function createJsonRpcCapabilities ({ safeMethods = [], restrictedMethods = {}, 
     });
   };
 
-  that.grantPermissionsMiddleware = function (domain, req, res, next, end) {
+  that.grantPermissionsMiddleware = function (granter, req, res, next, end) {
     // TODO: Validate params
-    const [ assignedDomain, requestedPerms ] = req.params;
-    const perms = that.getPermissionsForDomain(domain);
-    const assigned = that.getPermissionsForDomain(assignedDomain);
-    const newlyGranted = {};
+    const [ grantee, requestedPerms ] = req.params;
+    // const granteePerms = [ ...that.getPermissionsForDomain(grantee)];
+    const newlyGranted = [];
 
     let ended = false;
-    Object.keys(requestedPerms).forEach((methodName) => {
-      const perm = that.getPermission(domain, methodName);
+    requestedPerms.forEach((reqPerm) => {
+      const methodName = reqPerm.method;
+      const perm = that.getPermission(granter, methodName);
       if (perm) {
         const newPerm = {
           date: Date.now(),
-          grantedBy: domain,
+          granter: granter,
+          id: uuid(),
+          method: methodName,
         };
-        assigned[methodName] = newPerm;
-        newlyGranted[methodName] = newPerm;
+        // granteePerms.push(newPerm);
+        newlyGranted.push(newPerm);
       } else {
         res.error = UNAUTHORIZED_ERROR;
         ended = true;
@@ -336,7 +407,8 @@ function createJsonRpcCapabilities ({ safeMethods = [], restrictedMethods = {}, 
       return;
     }
 
-    that.setPermissionsFor(assignedDomain, assigned);
+    // that.setPermissionsFor(grantee, granteePerms);
+    that.setPermissionsFor(grantee, newlyGranted);
     res.result = newlyGranted;
     end();
   };
@@ -344,20 +416,23 @@ function createJsonRpcCapabilities ({ safeMethods = [], restrictedMethods = {}, 
   that.revokePermissionsMiddleware = function (domain, req, res, next, end) {
     // TODO: Validate params
     const [ assignedDomain, requestedPerms ] = req.params;
-    const perms = that.getPermissionsForDomain(domain);
-    const assigned = that.getPermissionsForDomain(assignedDomain);
     const newlyRevoked = [];
 
     let ended = false;
-    Object.keys(requestedPerms).forEach((methodName) => {
-      const perm = that.getPermissionUnTraversed(assignedDomain, methodName);
-      if (perm &&
-          // Grantors can revoke what they have granted:
-         ((perm.grantedBy && perm.grantedBy === domain)
-          // Domains can revoke their own permissions:
-          || (assignedDomain === domain))) {
-
-        newlyRevoked.push(methodName);
+    requestedPerms.forEach((reqPerm) => {
+      const methodName = reqPerm.method;
+      const perm = that.getPermissionUnTraversed(
+        assignedDomain, methodName, reqPerm.granter
+      );
+      if (
+            perm && (
+              // Grantors can revoke what they have granted:
+              (perm.granter && perm.granter === domain) ||
+              // Domains can revoke their own permissions:
+              (assignedDomain === domain)
+            )
+          ) {
+        newlyRevoked.push(perm);
       } else {
         res.error = UNAUTHORIZED_ERROR;
         ended = true;

--- a/index.js
+++ b/index.js
@@ -159,7 +159,7 @@ function createJsonRpcCapabilities ({
   that.getPermission = getPermission;
 
   /**
-   * Get the permission for that domain and method, not following granter links.
+   * Get the permission for that domain, granter, and method, not following granter links.
    * Returns the first such permission found.
    */
   that.getPermissionUnTraversed = function (domain, method, granter = undefined) {
@@ -167,11 +167,10 @@ function createJsonRpcCapabilities ({
     // https://w3c-ccg.github.io/ocap-ld/#caveats
 
     let permissions = that.getPermissionsForDomain(domain).filter(p => {
-      let out = p.method === method;
-      if (granter !== undefined) {
-        out = out && p.granter === granter;
-      }
-      return out;
+      return p.method === method && (
+        (p.granter === undefined && granter === domain) || // own permission
+        (p.granter !== undefined && p.granter === granter) // granted permission
+      );
     });
     if (permissions.length > 0) { return permissions.shift(); }
 
@@ -424,7 +423,7 @@ function createJsonRpcCapabilities ({
     requestedPerms.forEach((reqPerm) => {
       const methodName = reqPerm.method;
       const perm = that.getPermissionUnTraversed(
-        assignedDomain, methodName, reqPerm.granter
+        assignedDomain, methodName, domain
       );
       if (
             perm && (

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "json-rpc-capabilities-middleware",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -11,6 +11,56 @@
       "dev": true,
       "requires": {
         "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+      "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.4.0",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.11",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "2.5.2",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+          "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+      "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.4.0"
       }
     },
     "@babel/highlight": {
@@ -58,6 +108,82 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
+        }
+      }
+    },
+    "@babel/parser": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
+      "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ==",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
+      "integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.4.0",
+        "@babel/types": "^7.4.0"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
+      "integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.4.0",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.4.0",
+        "@babel/parser": "^7.4.3",
+        "@babel/types": "^7.4.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "globals": {
+          "version": "11.11.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+          "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+      "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.11",
+        "to-fast-properties": "^2.0.0"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
         }
       }
     },
@@ -150,6 +276,32 @@
         "private": "^0.1.8",
         "slash": "^1.0.0",
         "source-map": "^0.5.7"
+      }
+    },
+    "babel-eslint": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.1.tgz",
+      "integrity": "sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "^1.0.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "3.7.1",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+          "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        }
       }
     },
     "babel-generator": {
@@ -733,11 +885,6 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
-    },
-    "crypto-random-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
     },
     "debug": {
       "version": "2.6.9",
@@ -1346,9 +1493,9 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
-      "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -1990,6 +2137,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -12,15 +12,16 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "babel-eslint": "^10.0.1",
     "eslint": "^5.12.0",
     "eslint-config-jessie": "0.0.3",
     "tape": "^4.9.2"
   },
   "dependencies": {
     "clone": "^2.1.2",
-    "crypto-random-string": "^1.0.0",
     "fast-deep-equal": "^2.0.1",
     "json-rpc-error": "^2.0.0",
-    "obs-store": "^3.0.2"
+    "obs-store": "^3.0.2",
+    "uuid": "^3.3.2"
   }
 }

--- a/test/forwarding.js
+++ b/test/forwarding.js
@@ -95,11 +95,12 @@ test('requesting restricted method with permission is called', async (t) => {
     initState: {
       domains: {
         'login.metamask.io': {
-          permissions: {
-            'eth_write': {
+          permissions: [
+            {
+              method: 'eth_write',
               date: '0',
             }
-          }
+          ]
         }
       }
     },
@@ -124,7 +125,7 @@ test('requesting restricted method with permission is called', async (t) => {
   }
 
   function end(reason) {
-    t.error(reason, 'shuld not throw error')
+    t.error(reason, 'should not throw error')
     t.error(res.error, 'should not have error object')
     t.equal(res.result, WRITE_RESULT, 'Write result should be assigned.')
     t.end()

--- a/test/getPermissions.js
+++ b/test/getPermissions.js
@@ -6,8 +6,23 @@ const equal = require('fast-deep-equal')
 // Maybe submit to https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal
 const USER_REJECTION_CODE = 5
 
+const arbitraryCaps = [
+    {
+      domain: 'bar',
+      method: 'restricted',
+      granter: 'baz',
+      id: 'abc',
+    },
+    {
+      domain: 'baz',
+      method: 'restricted2',
+      granter: 'bar',
+      id: 'xyz',
+    },
+  ]
+
 test('getPermissions with none returns empty object', async (t) => {
-  const expected = {}
+  const expected = []
 
   const ctrl = createPermissionsMiddleware({})
 
@@ -30,10 +45,7 @@ test('getPermissions with none returns empty object', async (t) => {
 })
 
 test('getPermissions with some returns them', async (t) => {
-  const expected = {
-    'restricted': {},
-    'restricted2': { foo: 'bar' }
-  }
+  const expected = arbitraryCaps
 
   const ctrl = createPermissionsMiddleware({
     initState: {

--- a/test/grantPermissions.js
+++ b/test/grantPermissions.js
@@ -1,13 +1,14 @@
 const test = require('tape')
 const createPermissionsMiddleware = require('../')
 const equal = require('fast-deep-equal')
+const uuid = require('uuid/v4')
 
 // TODO: Standardize!
 // Maybe submit to https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal
 const USER_REJECTION_CODE = 5
 
 test('grantPermissions with no permission creates no permissions', async (t) => {
-  const expected = {}
+  const expected = []
 
   const ctrl = createPermissionsMiddleware({
   })
@@ -18,9 +19,11 @@ test('grantPermissions with no permission creates no permissions', async (t) => 
     method: 'grantPermissions',
     params: [
       otherDomain,
-      {
-        'restricted': {},
-      }
+      [
+        {
+          method: 'restricted',
+        },
+      ],
     ]
   }
   let res = {}
@@ -42,14 +45,24 @@ test('grantPermissions with no permission creates no permissions', async (t) => 
 })
 
 test('grantPermissions with permission creates permission', async (t) => {
+
   const expected = {
      domains: {
       'login.metamask.io': {
-        permissions: {
-          'restricted': {
+        permissions: [
+          {
+            method: 'restricted',
             date: '0',
           }
-        }
+        ]
+      },
+      'other.domain.com': {
+        permissions: [
+          {
+            method: 'restricted',
+            granter: 'login.metamask.io',
+          }
+        ]
       }
     }
   }
@@ -58,30 +71,33 @@ test('grantPermissions with permission creates permission', async (t) => {
     initState: {
       domains: {
         'login.metamask.io': {
-          permissions: {
-            'restricted': {
+          permissions: [
+            {
+              method: 'restricted',
               date: '0',
             }
-          },
+          ],
         }
       }
     }
   })
 
-  const domain = 'login.metamask.io'
-  const otherDomain = 'other.domain.com'
+  const granter = 'login.metamask.io'
+  const grantee = 'other.domain.com'
   let req = {
     method: 'grantPermissions',
     params: [
-      otherDomain,
-      {
-        'restricted': {},
-      }
+      grantee,
+      [
+        {
+          method: 'restricted',
+        },
+      ],
     ]
   }
   let res = {}
 
-  ctrl.providerMiddlewareFunction(domain, req, res, next, end)
+  ctrl.providerMiddlewareFunction(granter, req, res, next, end)
 
   function next() {
     t.ok(false, 'next should not be called')
@@ -93,26 +109,25 @@ test('grantPermissions with permission creates permission', async (t) => {
     t.notOk(reason, 'should throw no error')
     t.notOk(res.error, 'should assign no error')
 
-    const otherPerms = ctrl.getPermissionsForDomain(otherDomain)
+    const granteePerms = ctrl.getPermissionsForDomain(grantee)
 
-    for (let key in req.params[1]) {
-      t.ok(key in otherPerms, 'The requested permission was created.')
-    }
+    t.ok(granteePerms[0].method === req.params[1][0].method, 'The requested permission was created.')
     t.end()
   }
 })
 
-test('grantPermissions with permission whose grantor does not exist results in auth error', async (t) => {
+test('grantPermissions with permission whose granter does not exist results in auth error', async (t) => {
   const ctrl = createPermissionsMiddleware({
     initState: {
       domains: {
         'login.metamask.io': {
-          permissions: {
-            'restricted': {
-              grantedBy: 'other.domain2.io',
+          permissions: [
+            {
+              method: 'restricted',
+              granter: 'other.granter2.io',
               date: '0',
             }
-          },
+          ],
         }
       }
     }
@@ -124,9 +139,11 @@ test('grantPermissions with permission whose grantor does not exist results in a
     method: 'grantPermissions',
     params: [
       otherDomain,
-      {
-        'restricted': {},
-      }
+      [
+        {
+          method: 'restricted',
+        },
+      ],
     ]
   }
   let res = {}
@@ -145,3 +162,159 @@ test('grantPermissions with permission whose grantor does not exist results in a
   }
 })
 
+test('grantPermissions accumulates the same permission from different granters', async (t) => {
+
+  const grantee = 'login.metamask.io'
+  const granter1 = 'xyz.co.uk'
+  const granter2 = 'abc.se'
+
+  const expected = [
+    {
+      method: 'restricted',
+      date: '0',
+      granter: granter1,
+    },
+    {
+      method: 'restricted',
+      date: '0',
+      granter: granter2,
+    }
+  ]
+
+  const ctrl = createPermissionsMiddleware({
+    initState: {
+      domains: {
+        [grantee]: {
+          permissions: [
+            {
+              method: 'restricted',
+              date: '0',
+              granter: granter1,
+            }
+          ],
+        },
+        [granter2]: {
+          permissions: [
+            {
+              method: 'restricted',
+              date: '0',
+            }
+          ],
+        },
+      }
+    }
+  })
+
+  let req = {
+    method: 'grantPermissions',
+    params: [
+      grantee,
+      [
+        {
+          method: 'restricted',
+          date: '0',
+        },
+      ],
+    ]
+  }
+  let res = {}
+
+  ctrl.providerMiddlewareFunction(granter2, req, res, next, end)
+
+  function next() {
+    t.ok(false, 'next should not be called')
+    t.end()
+  }
+
+  function end(reason) {
+    t.error(reason, 'error should not be thrown')
+    t.notOk(reason, 'should throw no error')
+    t.notOk(res.error, 'should assign no error')
+
+    const otherPerms = ctrl.getPermissionsForDomain(grantee)
+
+    let result
+    for (let perm of otherPerms) {
+        result = perm.method === 'restricted' && (
+          perm.granter === granter1 ||
+          perm.granter === granter2
+        )
+    }
+    t.ok(result, 'the requested permission was created')
+    t.end()
+  }
+})
+
+test('grantPermissions replaces duplicate permissions', async (t) => {
+
+  const grantee = 'login.metamask.io'
+  const granter = 'xyz.co.uk'
+
+  const oldPerm = {
+    method: 'restricted',
+    id: uuid(),
+    date: Date.now(),
+    granter: granter,
+  }
+
+  const ctrl = createPermissionsMiddleware({
+    initState: {
+      domains: {
+        [grantee]: {
+          permissions: [
+            oldPerm
+          ],
+        },
+        [granter]: {
+          permissions: [
+            {
+              method: 'restricted',
+              date: '0',
+              id: uuid(),
+            }
+          ],
+        },
+      }
+    }
+  })
+
+  let req = {
+    method: 'grantPermissions',
+    params: [
+      grantee,
+      [
+        {
+          method: 'restricted'
+        },
+      ],
+    ]
+  }
+  let res = {}
+
+  ctrl.providerMiddlewareFunction(granter, req, res, next, end)
+
+  function next() {
+    t.ok(false, 'next should not be called')
+    t.end()
+  }
+
+  function end(reason) {
+    t.error(reason, 'error should not be thrown')
+    t.notOk(reason, 'should throw no error')
+    t.notOk(res.error, 'should assign no error')
+
+    const granteePerms = ctrl.getPermissionsForDomain(grantee)
+    t.ok(granteePerms.length === 1, 'grantee domain has a single permission')
+
+    const newPerm = granteePerms[0]
+    t.ok(
+      (
+        newPerm.method === oldPerm.method &&
+        newPerm.granter === oldPerm.granter &&
+        // newPerm.date > oldPerm.date && // becomes identical in test
+        newPerm.id !== oldPerm.id
+      ), 'the requested permission was created'
+    )
+    t.end()
+  }
+})

--- a/test/grantPermissions.js
+++ b/test/grantPermissions.js
@@ -212,7 +212,6 @@ test('grantPermissions accumulates the same permission from different granters',
       [
         {
           method: 'restricted',
-          date: '0',
         },
       ],
     ]

--- a/test/requestPermissions.js
+++ b/test/requestPermissions.js
@@ -7,7 +7,7 @@ const equal = require('fast-deep-equal')
 const USER_REJECTION_CODE = 5
 
 test('requestPermissions with user rejection creates no permissions', async (t) => {
-  const expected = {}
+  const expected = []
 
   const ctrl = LoginController({
     requestUserApproval: () => Promise.resolve(false),
@@ -17,9 +17,7 @@ test('requestPermissions with user rejection creates no permissions', async (t) 
   let req = {
     method: 'requestPermissions',
     params: [
-      {
-        'restricted': {},
-      }
+        ['restricted']
     ]
   }
   let res = {}
@@ -40,14 +38,16 @@ test('requestPermissions with user rejection creates no permissions', async (t) 
 })
 
 test('requestPermissions with user approval creates permission', async (t) => {
+
   const expected = {
      domains: {
       'login.metamask.io': {
-        permissions: {
-          'restricted': {
+        permissions: [
+          {
+            method: 'restricted',
             date: '0',
           }
-        }
+        ]
       }
     }
   }
@@ -61,9 +61,11 @@ test('requestPermissions with user approval creates permission', async (t) => {
   let req = {
     method: 'requestPermissions',
     params: [
-      {
-        'restricted': {},
-      }
+      [
+        {
+          method: 'restricted'
+        }
+      ]
     ]
   }
   let res = {}
@@ -101,12 +103,11 @@ test('requestPermissions with returned stub object defines future responses', as
 
     requestUserApproval: async (domain, req) => {
       return {
-        viewAccounts: {
-          caveats: [{
-            type: 'static',
-            value: expected,
-          }],
-        },
+        method: 'viewAccounts',
+        caveats: [{
+          type: 'static',
+          value: expected,
+        }],
       }
     },
   })
@@ -115,9 +116,11 @@ test('requestPermissions with returned stub object defines future responses', as
   let req = {
     method: 'requestPermissions',
     params: [
-      {
-        'viewAccounts': {},
-      }
+        [
+          {
+            method: 'viewAccounts'
+          }
+        ]
     ]
   }
 
@@ -125,7 +128,7 @@ test('requestPermissions with returned stub object defines future responses', as
     let res = await sendRpcMethodWithResponse(ctrl, domain, req)
 
     let accountsReq = {
-      method: Object.keys(req.params[0])[0], // 'viewAccounts'
+      method: req.params[0][0]['method'], // 'viewAccounts'
     }
 
     let result = await sendRpcMethodWithResponse(ctrl, domain, accountsReq)

--- a/test/revokePermissions.js
+++ b/test/revokePermissions.js
@@ -235,7 +235,6 @@ test('revokePermissions on specific granter and method deletes only the single i
       [
         {
           method: 'restricted',
-          granter: otherDomain,
         },
       ],
     ]
@@ -243,6 +242,11 @@ test('revokePermissions on specific granter and method deletes only the single i
   let res = {}
 
   ctrl.providerMiddlewareFunction(otherDomain, req, res, next, () => {})
+  console.log('-------------------------')
+  console.log(ctrl.getPermissionsForDomain(domain))
+  console.log('-------------------------')
+  console.log(ctrl.getPermissionsForDomain(otherDomain))
+  console.log('-------------------------')
 
   t.ok(equal(ctrl.getPermissionsForDomain(domain), expected), 'should have deleted target permission only')
 
@@ -324,11 +328,9 @@ test('revokePermissions deletes multiple permissions in single request', async (
       [
         {
           method: 'restricted1',
-          granter: otherDomain,
         },
         {
           method: 'restricted2',
-          granter: otherDomain,
         },
       ],
     ]

--- a/test/revokePermissions.js
+++ b/test/revokePermissions.js
@@ -182,12 +182,13 @@ test('revokePermissions on own permission deletes that permission.', async (t) =
 
 test('revokePermissions on specific granter and method deletes only the single intended permission', async (t) => {
 
-  const expected = [
+  const expected1 = [
     {
       method: 'restricted',
       date: '0'
     }
   ]
+  const expected2 = []
   const otherExpected = [
     {
       method: 'restricted',
@@ -243,7 +244,7 @@ test('revokePermissions on specific granter and method deletes only the single i
 
   ctrl.providerMiddlewareFunction(otherDomain, req, res, next, () => {})
 
-  t.ok(equal(ctrl.getPermissionsForDomain(domain), expected), 'should have deleted target permission only')
+  t.ok(equal(ctrl.getPermissionsForDomain(domain), expected1), 'should have deleted target permission only')
 
   req = {
     method: 'revokePermissions',
@@ -266,7 +267,7 @@ test('revokePermissions on specific granter and method deletes only the single i
 
   function end(reason) {
     t.error(reason, 'error should not be thrown')
-    t.ok(equal(ctrl.getPermissionsForDomain(domain), []), 'should have deleted the other permission')
+    t.ok(equal(ctrl.getPermissionsForDomain(domain), expected2), 'should have deleted the other permission')
     t.ok(equal(ctrl.getPermissionsForDomain(otherDomain), otherExpected), 'other domain unaffected')
     t.end()
   }

--- a/test/revokePermissions.js
+++ b/test/revokePermissions.js
@@ -242,11 +242,6 @@ test('revokePermissions on specific granter and method deletes only the single i
   let res = {}
 
   ctrl.providerMiddlewareFunction(otherDomain, req, res, next, () => {})
-  console.log('-------------------------')
-  console.log(ctrl.getPermissionsForDomain(domain))
-  console.log('-------------------------')
-  console.log(ctrl.getPermissionsForDomain(otherDomain))
-  console.log('-------------------------')
 
   t.ok(equal(ctrl.getPermissionsForDomain(domain), expected), 'should have deleted target permission only')
 


### PR DESCRIPTION
Refactored permissions to make them unique per domain, method, and granter. This allows multiple permissions with the same method to be granted to the same domain.

Implementing this required changing permission storage from `{ methodName: permissionObject }` objects to arrays of the form `[ permissionObject, ... ]`, partially breaking the existing API. 

Permissions objects have been refactored to the form:
```
{
  id: '63b225d0-414e-4a2d-8067-c34499c984c7', // uuid string
  method: 'restrictedMethodName',
  date: 0, // unix time of creation
  granter: 'another.domain.com', // Another domain string if created by delegation
  caveats: [ // An optional array describing limitations on the method reference.
    static: 'Always this!', // The static caveat only returns the specified static response.
  ]
}
```

Readme has been updated to reflect these changes, and tests have been added.

Solves #5.