### PR TITLE
Adds the forceParams caveat.

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Right now the supported caveat types are simple, to demonstrate the concept:
 
 - filterParams: Ensures that the method can only be called with a superset of some hard-defined parametersa.
 - filterResponse: Ensures that the response will only include explicitly permitted values in it (if an array).
+- forceParams: Requires the method to be called exactly with a specified list of params.
 
 Some caveat types we are looking forward to supporting eventually:
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Right now the supported caveat types are simple, to demonstrate the concept:
 
 - filterParams: Ensures that the method can only be called with a superset of some hard-defined parametersa.
 - filterResponse: Ensures that the response will only include explicitly permitted values in it (if an array).
-- forceParams: Requires the method to be called exactly with a specified list of params.
+- forceParams: Overwrites the params of all calls to the method with a specified list of params.
 
 Some caveat types we are looking forward to supporting eventually:
 

--- a/index.ts
+++ b/index.ts
@@ -17,6 +17,7 @@ import {
   ICaveatFunction,
   filterParams,
   filterResponse,
+  forceParams,
   ICaveatFunctionGenerator,
 } from './src/caveats';
 
@@ -88,7 +89,7 @@ export class CapabilitiesController extends BaseController<any, any> implements 
   private restrictedMethods: RestrictedMethodMap;
   private requestUserApproval: UserApprovalPrompt;
   private internalMethods: { [methodName: string]: AuthenticatedJsonRpcMiddleware }
-  private caveats: { [ name: string]: ICaveatFunctionGenerator } = { filterParams, filterResponse };
+  private caveats: { [ name: string]: ICaveatFunctionGenerator } = { filterParams, filterResponse, forceParams };
   private methodPrefix: string;
   private engine: JsonRpcEngine | undefined;
 

--- a/src/caveats.ts
+++ b/src/caveats.ts
@@ -51,3 +51,14 @@ export const filterResponse: ICaveatFunctionGenerator = function filterResponse(
     });
   }
 }
+
+/*
+ * Forces the method to be called with given params
+ */
+export const filterResponse: ICaveatFunctionGenerator = function filterResponse(serialized: ISerializedCaveat) {
+  const { value } = serialized;
+  return (req, res, next, end) => {
+      req.params = [...value.params]
+      next();
+  };
+}

--- a/src/caveats.ts
+++ b/src/caveats.ts
@@ -55,10 +55,10 @@ export const filterResponse: ICaveatFunctionGenerator = function filterResponse(
 /*
  * Forces the method to be called with given params
  */
-export const filterResponse: ICaveatFunctionGenerator = function filterResponse(serialized: ISerializedCaveat) {
+export const forceParams: ICaveatFunctionGenerator = function forceParams(serialized: ISerializedCaveat) {
   const { value } = serialized;
-  return (req, res, next, end) => {
-      req.params = [...value.params]
+  return (req, _, next) => {
+      req.params = [ ...value ]
       next();
   };
 }


### PR DESCRIPTION
This PR adds a caveat that would require every call of the method to be called with only the params specified within the permission request caveat.