### PR TITLE
Fix wildcard support for multiply nested wildcards

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -222,24 +222,20 @@ export class CapabilitiesController extends BaseController<any, any> implements 
     // Check for potentially nested namespaces:
     // Ex: wildzone_
     // Ex: eth_plugin_
-    if (method.indexOf('_') > 0) {
 
-      const segments = method.split('_');
-      let managed = '';
+    const segments = method.split('_');
+    let managed = '';
 
-      while (segments.length > 0 && !managedMethods.includes(managed) && !wildCardMethodsWithoutWildCard[managed]) {
-        managed += segments.shift() + '_';
-      }
+    while (segments.length > 0 && !managedMethods.includes(managed) && !wildCardMethodsWithoutWildCard[managed]) {
+      managed += segments.shift() + '_';
+    }
 
-      if (managedMethods.includes(managed)) {
-        return managed;
-      } else if (wildCardMethodsWithoutWildCard[managed]) {
-        return managed + '*';
-      } else {
-        return '';
-      }
+    if (managedMethods.includes(managed)) {
+      return managed;
+    } else if (wildCardMethodsWithoutWildCard[managed]) {
+      return managed + '*';
     } else {
-      return managedMethods.includes(method) ? method : '';
+      return '';
     }
   }
 

--- a/index.ts
+++ b/index.ts
@@ -212,6 +212,13 @@ export class CapabilitiesController extends BaseController<any, any> implements 
       return method;
     }
 
+    const wildCardMethodsWithoutWildCard = managedMethods.reduce<{[key: string]: boolean}>(
+      (acc, methodName) => {
+        const wildCardMatch = methodName.match(/(.+)\*$/)
+        return wildCardMatch ? { ...acc, [wildCardMatch[1]]: true } : acc
+      },
+    {});
+
     // Check for potentially nested namespaces:
     // Ex: wildzone_
     // Ex: eth_plugin_
@@ -220,12 +227,14 @@ export class CapabilitiesController extends BaseController<any, any> implements 
       const segments = method.split('_');
       let managed = '';
 
-      while (segments.length > 0 && !managedMethods.includes(managed)) {
+      while (segments.length > 0 && !managedMethods.includes(managed) && !wildCardMethodsWithoutWildCard[managed]) {
         managed += segments.shift() + '_';
       }
 
       if (managedMethods.includes(managed)) {
         return managed;
+      } else if (wildCardMethodsWithoutWildCard[managed]) {
+        return managed + '*';
       } else {
         return '';
       }

--- a/test/wildcardPermissions.js
+++ b/test/wildcardPermissions.js
@@ -52,6 +52,96 @@ test('requestPermissions on namespaced method with user approval creates permiss
   }
 });
 
+test('requestPermissions on twice namespaced method with user approval creates permission', async (t) => {
+
+  const ctrl = new CapabilitiesController({
+
+    // Auto fully approve:
+    requestUserApproval: (reqPerms) => Promise.resolve(reqPerms.permissions),
+
+    restrictedMethods: {
+
+      'eth_plugin_': {
+        description: "Permission to install plugin",
+        method: (req, res, next, end) => {
+          const parts = req.method.split('_');
+          const second = parts[2];
+          res.result = second;
+          end();
+        }
+      }
+    },
+
+  })
+
+  const domain = { origin: 'login.metamask.io' }
+  let req = {
+    method: 'requestPermissions',
+    params: [
+      {
+        eth_plugin_A: {}
+      }
+    ]
+  }
+
+  try {
+    let res = await sendRpcMethodWithResponse(ctrl, domain, req);
+    req = { method: 'eth_plugin_A' };
+    res = await sendRpcMethodWithResponse(ctrl, domain, req);
+    t.equal(res.result, 'A', 'returned the segment correctly.');
+    t.end()
+
+  } catch (error) {
+    t.error(error, 'error should not be thrown')
+    t.end();
+  }
+});
+
+test('requestPermissions on namespaced method ending in a wildcard with user approval creates permission', async (t) => {
+
+  const ctrl = new CapabilitiesController({
+
+    // Auto fully approve:
+    requestUserApproval: (reqPerms) => Promise.resolve(reqPerms.permissions),
+
+    restrictedMethods: {
+
+      'eth_plugin_*': {
+        description: "Permission to install plugin",
+        method: (req, res, next, end) => {
+          const parts = req.method.split('_');
+          const second = parts[2];
+          res.result = second;
+          end();
+        }
+      }
+    },
+
+  })
+
+  const domain = { origin: 'login.metamask.io' }
+  let req = {
+    method: 'requestPermissions',
+    params: [
+      {
+        eth_plugin_A: {}
+      }
+    ]
+  }
+
+  try {
+    let res = await sendRpcMethodWithResponse(ctrl, domain, req);
+    req = { method: 'eth_plugin_A' };
+    res = await sendRpcMethodWithResponse(ctrl, domain, req);
+    t.equal(res.result, 'A', 'returned the segment correctly.');
+    t.end()
+
+  } catch (error) {
+    t.error(error, 'error should not be thrown')
+    t.end();
+  }
+});
+
 test('requestPermissions on namespaced method with user approval does not permit other namespaces', async (t) => {
 
   const ctrl = new CapabilitiesController({


### PR DESCRIPTION
This PR fixes the support for methods that end in a wildcard character `*`, and include two or more underscores to separate nested parts of the method name.