### PR TITLE
Improve RPC errors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,7 @@
   "plugins": ["@typescript-eslint"],
   "extends": ["plugin:@typescript-eslint/recommended"],
   "rules": {
-      "@typescript-eslint/no-var-requires": "off"
+      "@typescript-eslint/no-var-requires": "off",
+      "@typescript-eslint/no-explicit-any": "off"
   }
 }

--- a/index.ts
+++ b/index.ts
@@ -39,12 +39,12 @@ import {
 import {
   unauthorized,
   invalidReq,
-  USER_REJECTED_ERROR,
-  METHOD_NOT_FOUND
+  userRejectedRequest,
+  methodNotFound
 } from './src/errors';
 
 export interface AnnotatedJsonRpcEngine extends JsonRpcEngine {
-  domain?: IOriginString
+  domain?: IOriginString;
 }
 
 import { IOcapLdCapability, IOcapLdCaveat } from './src/@types/ocap-ld';
@@ -132,6 +132,7 @@ export class CapabilitiesController extends BaseController<any, any> implements 
   serialize () {
     return this.state;
   }
+
   /**
    * Returns a capabilities middleware function bound to its parent
    * CapabilitiesController object with the given domain as its
@@ -279,8 +280,8 @@ export class CapabilitiesController extends BaseController<any, any> implements 
       }
     }
 
-    res.error = METHOD_NOT_FOUND;
-    return end(METHOD_NOT_FOUND);
+    res.error = methodNotFound(req);
+    return end(res.error);
   }
 
   createVirtualEngineFor (domain: IOriginMetadata): AnnotatedJsonRpcEngine {
@@ -365,7 +366,7 @@ export class CapabilitiesController extends BaseController<any, any> implements 
     for (const methodName in approved) {
       const exists = this.getMethodKeyFor(methodName);
       if (!exists) {
-        res.error = METHOD_NOT_FOUND;
+        res.error = methodNotFound(methodName);
         return end(res.error);
       }
     }
@@ -571,8 +572,8 @@ export class CapabilitiesController extends BaseController<any, any> implements 
     // the approved permissions, allowing user-customization.
     .then((approved: IRequestedPermissions) => {
       if (Object.keys(approved).length === 0) {
-        res.error = USER_REJECTED_ERROR;
-        return end(USER_REJECTED_ERROR);
+        res.error = userRejectedRequest(req);
+        return end(res.error);
       }
 
       if (!permissionsRequest.metadata.id) {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "clone": "^2.1.2",
-    "eth-json-rpc-errors": "^1.0.1",
+    "eth-json-rpc-errors": "^2.0.0",
     "fast-deep-equal": "^2.0.1",
     "gaba": "^1.6.0",
     "intersect-objects": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-rpc-capabilities-middleware",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,27 +1,25 @@
 import { JsonRpcRequest } from 'json-rpc-engine';
 
-import { IRpcErrors, IJsonRpcError } from 'eth-json-rpc-errors/@types';
+import { IEthErrors, IEthereumRpcError } from 'eth-json-rpc-errors/@types';
 
-const rpcErrors: IRpcErrors = require('eth-json-rpc-errors').errors;
+const ethErrors: IEthErrors = require('eth-json-rpc-errors').ethErrors;
 
-// TODO: standardize
-const USER_REJECTED_ERROR_CODE = 4002;
-const USER_REJECTED_ERROR_MESSAGE = 'User rejected the request.';
-
-function unauthorized (request?: JsonRpcRequest<any>): IJsonRpcError<JsonRpcRequest<any>> {
-  return rpcErrors.eth.unauthorized(
-    'Unauthorized to perform action. Try requesting permission first using the `requestPermissions` method. More info available at https://github.com/MetaMask/json-rpc-capabilities-middleware',
-    request
-  );
+function unauthorized (request?: JsonRpcRequest<any>): IEthereumRpcError<JsonRpcRequest<any>> {
+  return ethErrors.provider.unauthorized({
+    message: 'Unauthorized to perform action. Try requesting permission first using the `requestPermissions` method. More info available at https://github.com/MetaMask/json-rpc-capabilities-middleware',
+    data: request
+  });
 }
 
-function invalidReq (request?: JsonRpcRequest<any>): IJsonRpcError<JsonRpcRequest<any>> {
-  return rpcErrors.invalidRequest(null, request);
+function invalidReq (request?: JsonRpcRequest<any>): IEthereumRpcError<JsonRpcRequest<any>> {
+  return ethErrors.rpc.invalidRequest({ data: request });
 }
 
-const METHOD_NOT_FOUND: IJsonRpcError<undefined> = rpcErrors.methodNotFound();
-const USER_REJECTED_ERROR: IJsonRpcError<undefined> = rpcErrors.eth.custom(
-  USER_REJECTED_ERROR_CODE, USER_REJECTED_ERROR_MESSAGE
-);
+function methodNotFound (data?: any): IEthereumRpcError<JsonRpcRequest<any>> {
+  return ethErrors.rpc.methodNotFound({ data });
+}
 
-export { unauthorized, METHOD_NOT_FOUND, invalidReq, USER_REJECTED_ERROR };
+function userRejectedRequest (request?: JsonRpcRequest<any>): IEthereumRpcError<JsonRpcRequest<any>> {
+  return ethErrors.provider.userRejectedRequest({ data: request });
+}
+export { unauthorized, methodNotFound, invalidReq, userRejectedRequest };

--- a/test/caveats.js
+++ b/test/caveats.js
@@ -4,7 +4,7 @@ const test = require('tape');
 const CapabilitiesController = require('../dist').CapabilitiesController
 const sendRpcMethodWithResponse = require('./lib/utils').sendRpcMethodWithResponse;
 
-const UNAUTHORIZED_CODE = require('eth-json-rpc-errors').ERROR_CODES.eth.unauthorized
+const UNAUTHORIZED_CODE = require('eth-json-rpc-errors').ERROR_CODES.provider.unauthorized
 
 test('filterParams caveat throws if params are not a subset.', async (t) => {
   const domain = { origin: 'www.metamask.io' };

--- a/test/dependentPermissions.js
+++ b/test/dependentPermissions.js
@@ -1,9 +1,6 @@
 const test = require('tape')
 const CapabilitiesController = require('../dist').CapabilitiesController;
-const equal = require('fast-deep-equal')
 const JsonRpcEngine = require('json-rpc-engine');
-
-const UNAUTHORIZED_CODE = require('eth-json-rpc-errors').ERROR_CODES.eth.unauthorized;
 
 test('restricted permission gets restricted provider', async (t) => {
   const name = 'Glen Runciter';

--- a/test/forwarding.js
+++ b/test/forwarding.js
@@ -1,7 +1,7 @@
 const test = require('tape');
 const CapabilitiesController = require('../dist').CapabilitiesController
 
-const UNAUTHORIZED_CODE = require('eth-json-rpc-errors').ERROR_CODES.eth.unauthorized
+const UNAUTHORIZED_CODE = require('eth-json-rpc-errors').ERROR_CODES.provider.unauthorized
 
 test('safe method should pass through', async (t) => {
   const WRITE_RESULT = 'impeccable result'

--- a/test/requestPermissions.js
+++ b/test/requestPermissions.js
@@ -3,8 +3,8 @@ const CapabilitiesController = require('../dist').CapabilitiesController;
 const equal = require('fast-deep-equal')
 const rpcErrors = require('eth-json-rpc-errors')
 
-const USER_REJECTION_CODE = require('../dist/src/errors').USER_REJECTED_ERROR.code
-const INVALID_REQUEST_CODE = rpcErrors.ERROR_CODES.jsonRpc.invalidRequest
+const USER_REJECTION_CODE = rpcErrors.ERROR_CODES.provider.userRejectedRequest
+const INVALID_REQUEST_CODE = rpcErrors.ERROR_CODES.rpc.invalidRequest
 
 test('requestPermissions with user rejection creates no permissions', async (t) => {
   const expected = []

--- a/test/wildcardPermissions.js
+++ b/test/wildcardPermissions.js
@@ -1,8 +1,7 @@
 const test = require('tape')
 const CapabilitiesController = require('../dist').CapabilitiesController;
-const equal = require('fast-deep-equal')
 
-const UNAUTHORIZED_CODE = require('eth-json-rpc-errors').ERROR_CODES.eth.unauthorized
+const UNAUTHORIZED_CODE = require('eth-json-rpc-errors').ERROR_CODES.provider.unauthorized
 
 test('requestPermissions on namespaced method with user approval creates permission', async (t) => {
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -924,6 +924,13 @@ eth-json-rpc-errors@^1.0.1:
   dependencies:
     fast-safe-stringify "^2.0.6"
 
+eth-json-rpc-errors@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eth-json-rpc-errors/-/eth-json-rpc-errors-2.0.0.tgz#bdc19df8b80a820844709193372f0d75fb74fed8"
+  integrity sha512-casdSTVOxbC3ptfUdclJRvU0Sgmdm/QtezLku8l4iVR5wNFe+KF+tfnlm2I84xxpx7mkyyHeeUxmRkcB5Os6mw==
+  dependencies:
+    fast-safe-stringify "^2.0.6"
+
 eth-json-rpc-filters@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/eth-json-rpc-filters/-/eth-json-rpc-filters-4.1.0.tgz#e7357a38983cde29858818dc55d394b9cf47c0f0"


### PR DESCRIPTION
Added `data` to some returned errors that were missing it, usually in the form of the original request.

Updated `eth-json-rpc-errors` to latest.

Updated ESLint rules.

Bump version: `0.16.1` -> `0.16.2`