### PR TITLE
Enable updating caveats

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,7 @@
   "rules": {
       "@typescript-eslint/no-var-requires": "off",
       "@typescript-eslint/no-explicit-any": "off",
-      "@typescript-eslint/void-require": "off"
+      "@typescript-eslint/void-require": "off",
+      "semi": 2
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,7 @@
   "extends": ["plugin:@typescript-eslint/recommended"],
   "rules": {
       "@typescript-eslint/no-var-requires": "off",
-      "@typescript-eslint/no-explicit-any": "off"
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/void-require": "off"
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ index.js
 dist/
 .python-version
 *.log
+.nyc_output

--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ diagrams
 .DS_Store
 .circleci
 .python-version
+.nyc_output

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,4 @@
+{
+  "extends": "@istanbuljs/nyc-config-typescript",
+  "all": true
+}

--- a/index.ts
+++ b/index.ts
@@ -474,7 +474,7 @@ export class CapabilitiesController extends BaseController<any, any> implements 
     if (this.semanticCaveatTypes) {
       const allTypes = this.semanticCaveatTypes; // typescript complains otherwise
       const seenTypes: { [key: string]: boolean } = {}
-      for (let c of caveats) {
+      for (const c of caveats) {
         if (
           !c.semanticType ||
           !allTypes[c.semanticType] ||
@@ -506,7 +506,7 @@ export class CapabilitiesController extends BaseController<any, any> implements 
     if (!this.semanticCaveatTypes) {
       throw internalError({
         message: 'This permissions controller is not configured for semantic caveats.'
-      })
+      });
     }
 
     // assert caveat is valid
@@ -518,7 +518,7 @@ export class CapabilitiesController extends BaseController<any, any> implements 
       throw internalError({
         message: 'Invalid caveat param. Must be valid caveat object.',
         data: caveat,
-      })
+      });
     }
 
     // assert domain exists
@@ -526,7 +526,7 @@ export class CapabilitiesController extends BaseController<any, any> implements 
       throw unauthorized({
         message: 'Unknown domain.',
         data: domainName,
-      })
+      });
     }
 
     // assert method exists
@@ -541,23 +541,23 @@ export class CapabilitiesController extends BaseController<any, any> implements 
       throw unauthorized({
         message: 'No such permissions exists for the given domain.',
         data: { domain: domainName, method: methodName },
-      })
+      });
     }
 
     // copy over all caveats except the target
     const newCaveats: IOcapLdCaveat[] = []
     perm.caveats && perm.caveats.forEach(c => {
       if (c.semanticType !== caveat.semanticType) {
-        newCaveats.push(c)
+        newCaveats.push(c);
       }
-    })
+    });
 
     // assert that the target caveat exists
     if (!perm.caveats || newCaveats.length !== perm.caveats.length - 1) {
       throw unauthorized({
         message: 'No such semantic caveat type exists for the relevant permission.',
         data: caveat.semanticType
-      })
+      });
     }
 
     // create new caveats, and assert that they are valid
@@ -566,13 +566,13 @@ export class CapabilitiesController extends BaseController<any, any> implements 
       throw internalError({
         message: 'The new caveats are jointly invalid.',
         data: newCaveats,
-      })
+      });
     }
 
     // construct new permission with new caveat
     const newPermissions: { [methodName: string]: IOcapLdCapability } = {};
-    perm.caveats = newCaveats
-    newPermissions[methodName] = perm
+    perm.caveats = newCaveats;
+    newPermissions[methodName] = perm;
 
     // overwrite the existing permission, completing the update
     this.addPermissionsFor(domainName, newPermissions);
@@ -612,7 +612,7 @@ export class CapabilitiesController extends BaseController<any, any> implements 
    * Clear all domains (and thereby remove all permissions).
    */
   clearDomains (): void {
-    this.setDomains({})
+    this.setDomains({});
   }
 
   /**
@@ -669,8 +669,7 @@ export class CapabilitiesController extends BaseController<any, any> implements 
   ): void {
 
     // validate request
-    if (!this.isValidPermissionsRequest(req)
-    ) {
+    if (!this.isValidPermissionsRequest(req)) {
       res.error = invalidReq({ data: req});
       return end(res.error);
     }
@@ -715,7 +714,7 @@ export class CapabilitiesController extends BaseController<any, any> implements 
     .finally(() => {
       // Delete the request object
       if (permissionsRequest.metadata.id) {
-        this.removePermissionsRequest(permissionsRequest.metadata.id)
+        this.removePermissionsRequest(permissionsRequest.metadata.id);
       }
     });
   }

--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "test": "ts-node test",
     "build": "rm -rf dist && tsc",
     "build:watch": "yarn build && tsc -w",
-    "test:clean": "yarn build && yarn test",
     "lint": "./node_modules/.bin/eslint index.ts",
-    "lint:fix": "./node_modules/.bin/eslint index.ts --fix"
+    "lint:fix": "./node_modules/.bin/eslint index.ts --fix",
+    "test": "ts-node test",
+    "test:clean": "yarn build && yarn test",
+    "test:coverage": "nyc ts-node test"
   },
   "keywords": [],
   "author": "",
@@ -20,12 +21,14 @@
     "url": "git+https://github.com/MetaMask/json-rpc-capabilities-middleware.git"
   },
   "devDependencies": {
+    "@istanbuljs/nyc-config-typescript": "^0.1.3",
     "@types/node": "^12.0.7",
     "@types/uuid": "^3.4.4",
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
     "eslint": "^6.2.1",
     "http-server": "^0.11.1",
+    "nyc": "^14.1.1",
     "tape": "^4.9.2",
     "ts-node": "^8.2.0",
     "typescript": "^3.5.1"

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -64,7 +64,7 @@ export interface CapabilitiesConfig {
   methodPrefix?: string;
   restrictedMethods?: RestrictedMethodMap;
   safeMethods?: string[];
-  semanticCaveatTypes?: { [semanticType: string]: ISemanticCaveatTypeConfig };
+  semanticCaveatTypes?: { [name: string]: ISemanticCaveatTypeConfig };
 }
 
 type RpcCapDomainRegistry = { [domain:string]: RpcCapDomainEntry };

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -55,13 +55,16 @@ export interface RpcCapDomainEntry {
 
 type IOriginString = string;
 
+export interface ISemanticCaveatTypeConfig {}
+
 export interface CapabilitiesConfig {
-  safeMethods?: string[];
-  restrictedMethods?: RestrictedMethodMap;
-  initState?: CapabilitiesConfig;
-  methodPrefix?: string;
   requestUserApproval: UserApprovalPrompt;
   engine?: JsonRpcEngine;
+  initState?: CapabilitiesConfig;
+  methodPrefix?: string;
+  restrictedMethods?: RestrictedMethodMap;
+  safeMethods?: string[];
+  semanticCaveatTypes?: { [semanticType: string]: ISemanticCaveatTypeConfig };
 }
 
 type RpcCapDomainRegistry = { [domain:string]: RpcCapDomainEntry };

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -11,7 +11,7 @@ export interface AuthenticatedJsonRpcMiddleware {
     res: JsonRpcResponse<any>,
     next: JsonRpcEngineNextCallback,
     end: JsonRpcEngineEndCallback,
-  ) : void;
+  ): void;
 }
 
 /**

--- a/src/@types/ocap-ld.d.ts
+++ b/src/@types/ocap-ld.d.ts
@@ -30,8 +30,8 @@ export type IOcapLdCaveat = {
   type: string,
   // Any additional data required to enforce the caveat type.
   value?: any;
-  // MetaMask semantic type
-  semanticType?: string;
+  // Unique identifier for use in the client layer
+  name?: string;
 }
 
 export type IOcapLdProof = {

--- a/src/@types/ocap-ld.d.ts
+++ b/src/@types/ocap-ld.d.ts
@@ -30,6 +30,8 @@ export type IOcapLdCaveat = {
   type: string,
   // Any additional data required to enforce the caveat type.
   value?: any;
+  // MetaMask semantic type
+  semanticType?: string;
 }
 
 export type IOcapLdProof = {

--- a/src/caveats.ts
+++ b/src/caveats.ts
@@ -1,24 +1,24 @@
 /// <reference path="./@types/is-subset.d.ts" />
 
 import { JsonRpcMiddleware } from 'json-rpc-engine';
-import { isSubset } from "./@types/is-subset";
+import { isSubset } from './@types/is-subset';
+import { IOcapLdCaveat } from './@types/ocap-ld'
 import { unauthorized } from './errors';
 const isSubset = require('is-subset');
 
-export interface ISerializedCaveat {
-  type: string;
-  value?: any;
+export interface ISemanticCaveat extends IOcapLdCaveat {
+  semanticType: string;
 }
 
 export type ICaveatFunction = JsonRpcMiddleware;
 
-export type ICaveatFunctionGenerator = (caveat:ISerializedCaveat) => ICaveatFunction;
+export type ICaveatFunctionGenerator = (caveat:IOcapLdCaveat) => ICaveatFunction;
 
 /*
  * Filters params shallowly.
  * MVP caveats with lots of room for enhancement later.
  */
-export const filterParams: ICaveatFunctionGenerator = function filterParams(serialized: ISerializedCaveat) {
+export const filterParams: ICaveatFunctionGenerator = function filterParams(serialized: IOcapLdCaveat) {
   const { value } = serialized;
   return (req, res, next, end) => {
     const permitted = isSubset(req.params, value);
@@ -37,7 +37,7 @@ export const filterParams: ICaveatFunctionGenerator = function filterParams(seri
  * MVP caveat for signing in with accounts.
  * Lots of room for enhancement later.
  */
-export const filterResponse: ICaveatFunctionGenerator = function filterResponse(serialized: ISerializedCaveat) {
+export const filterResponse: ICaveatFunctionGenerator = function filterResponse(serialized: IOcapLdCaveat) {
   const { value } = serialized;
   return (_req, res, next, _end) => {
 
@@ -55,7 +55,7 @@ export const filterResponse: ICaveatFunctionGenerator = function filterResponse(
 /*
  * Forces the method to be called with given params
  */
-export const forceParams: ICaveatFunctionGenerator = function forceParams(serialized: ISerializedCaveat) {
+export const forceParams: ICaveatFunctionGenerator = function forceParams(serialized: IOcapLdCaveat) {
   const { value } = serialized;
   return (req, _, next) => {
       req.params = [ ...value ]

--- a/src/caveats.ts
+++ b/src/caveats.ts
@@ -6,10 +6,6 @@ import { IOcapLdCaveat } from './@types/ocap-ld'
 import { unauthorized } from './errors';
 const isSubset = require('is-subset');
 
-export interface ISemanticCaveat extends IOcapLdCaveat {
-  semanticType: string;
-}
-
 export type ICaveatFunction = JsonRpcMiddleware;
 
 export type ICaveatFunctionGenerator = (caveat:IOcapLdCaveat) => ICaveatFunction;

--- a/src/caveats.ts
+++ b/src/caveats.ts
@@ -24,7 +24,7 @@ export const filterParams: ICaveatFunctionGenerator = function filterParams(seri
     const permitted = isSubset(req.params, value);
 
     if (!permitted) {
-      res.error = unauthorized(req);
+      res.error = unauthorized({ data: req });
       return end(res.error);
     }
 

--- a/src/caveats.ts
+++ b/src/caveats.ts
@@ -5,7 +5,7 @@ import { isSubset } from "./@types/is-subset";
 import { unauthorized } from './errors';
 const isSubset = require('is-subset');
 
-interface ISerializedCaveat {
+export interface ISerializedCaveat {
   type: string;
   value?: any;
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -4,10 +4,15 @@ import { IEthErrors, IEthereumRpcError } from 'eth-json-rpc-errors/@types';
 
 const ethErrors: IEthErrors = require('eth-json-rpc-errors').ethErrors;
 
-function unauthorized (request?: JsonRpcRequest<any>): IEthereumRpcError<JsonRpcRequest<any>> {
+interface ErrorArg {
+  message?: string,
+  data?: JsonRpcRequest<any> | any
+}
+
+function unauthorized (arg?: ErrorArg): IEthereumRpcError<JsonRpcRequest<any>> {
   return ethErrors.provider.unauthorized({
-    message: 'Unauthorized to perform action. Try requesting permission first using the `requestPermissions` method. More info available at https://github.com/MetaMask/json-rpc-capabilities-middleware',
-    data: request
+    message: (arg && arg.message) || 'Unauthorized to perform action. Try requesting permission first using the `requestPermissions` method. More info available at https://github.com/MetaMask/json-rpc-capabilities-middleware',
+    data: arg && arg.data
   });
 }
 
@@ -22,4 +27,4 @@ function methodNotFound (data?: any): IEthereumRpcError<JsonRpcRequest<any>> {
 function userRejectedRequest (request?: JsonRpcRequest<any>): IEthereumRpcError<JsonRpcRequest<any>> {
   return ethErrors.provider.userRejectedRequest({ data: request });
 }
-export { unauthorized, methodNotFound, invalidReq, userRejectedRequest };
+export { unauthorized, methodNotFound, invalidReq, userRejectedRequest, IEthErrors };

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -12,13 +12,13 @@ interface ErrorArg {
 function unauthorized (arg?: ErrorArg): IEthereumRpcError<JsonRpcRequest<any>> {
   return ethErrors.provider.unauthorized({
     message: (arg && arg.message) || 'Unauthorized to perform action. Try requesting permission first using the `requestPermissions` method. More info available at https://github.com/MetaMask/json-rpc-capabilities-middleware',
-    data: arg && arg.data
+    data: (arg && arg.data) || undefined
   });
 }
 
-function invalidReq (request?: JsonRpcRequest<any>): IEthereumRpcError<JsonRpcRequest<any>> {
-  return ethErrors.rpc.invalidRequest({ data: request });
-}
+const invalidReq = ethErrors.rpc.invalidRequest
+
+const internalError = ethErrors.rpc.internal
 
 function methodNotFound (data?: any): IEthereumRpcError<JsonRpcRequest<any>> {
   return ethErrors.rpc.methodNotFound({ data });
@@ -27,4 +27,4 @@ function methodNotFound (data?: any): IEthereumRpcError<JsonRpcRequest<any>> {
 function userRejectedRequest (request?: JsonRpcRequest<any>): IEthereumRpcError<JsonRpcRequest<any>> {
   return ethErrors.provider.userRejectedRequest({ data: request });
 }
-export { unauthorized, methodNotFound, invalidReq, userRejectedRequest, IEthErrors };
+export { unauthorized, methodNotFound, invalidReq, internalError, userRejectedRequest, IEthErrors };

--- a/test/caveats.js
+++ b/test/caveats.js
@@ -469,11 +469,7 @@ test('updateCaveatFor', async (t) => {
       try {
 
         ctrl.updateCaveatFor(
-          'foo.bar.xyz', 'testMethod', {
-            type: 'forceParams',
-            value: [0,1],
-            name: 'a'
-          }
+          'foo.bar.xyz', 'testMethod', 'a', [0,1]
         )
 
         t.notOk(true, 'should have thrown')
@@ -489,11 +485,7 @@ test('updateCaveatFor', async (t) => {
       try {
 
         ctrl.updateCaveatFor(
-          domain.origin, 'doesNotExist', {
-            type: 'forceParams',
-            value: [0,1],
-            name: 'a'
-          }
+          domain.origin, 'doesNotExist', 'a', [0,1]
         )
 
         t.notOk(true, 'should have thrown')
@@ -530,11 +522,7 @@ test('updateCaveatFor', async (t) => {
         cav1.value = [0,1,2]
 
         ctrl.updateCaveatFor(
-          domain.origin, 'testMethod', {
-            type: 'forceParams',
-            value: cav1.value,
-            name: 'a'
-          }
+          domain.origin, 'testMethod', 'a', cav1.value
         )
 
         req = {
@@ -557,11 +545,23 @@ test('updateCaveatFor', async (t) => {
       try {
 
         ctrl.updateCaveatFor(
-          domain.origin, 'testMethod', {
-            type: 'forceParams',
-            value: [0,1],
-            name: 'b'
-          }
+          domain.origin, 'testMethod', 'b', [0,1]
+        )
+
+        t.notOk(true, 'should have thrown')
+
+      } catch (err) {
+        t.ok(err, 'did throw')
+      }
+      t.end()
+    })
+
+    test('updateCaveatFor throws on existing caveat but different value type', async (t) => {
+
+      try {
+
+        ctrl.updateCaveatFor(
+          domain.origin, 'testMethod', 'b', 'foo'
         )
 
         t.notOk(true, 'should have thrown')

--- a/test/caveats.js
+++ b/test/caveats.js
@@ -44,7 +44,7 @@ test('filterParams caveat throws if params are not a subset.', async (t) => {
       ]
     };
 
-    let res = await sendRpcMethodWithResponse(ctrl, domain, req);
+    await sendRpcMethodWithResponse(ctrl, domain, req);
 
     // Now let's call that restricted method:
     req = {
@@ -55,13 +55,14 @@ test('filterParams caveat throws if params are not a subset.', async (t) => {
       ]
     }
 
-    const result = await sendRpcMethodWithResponse(ctrl, domain, req);
+    await sendRpcMethodWithResponse(ctrl, domain, req);
+    t.notOk(true, 'should have thrown')
 
   } catch (err) {
     t.ok(err, 'should throw');
     t.equal(err.code, UNAUTHORIZED_CODE, 'Auth error code.');
-    t.end();
   }
+  t.end();
 })
 
 test('filterParams caveat passes through if params are a subset.', async (t) => {
@@ -117,12 +118,11 @@ test('filterParams caveat passes through if params are a subset.', async (t) => 
 
     t.ok(result, 'should succeed');
     t.equal(result, 'Success', 'Just returned the request');
-    t.end();
 
   } catch (err) {
     t.notOk(err, 'should not throw');
-    t.end();
   }
+  t.end();
 })
 
 test('filterResponse caveat returns empty if params are not a subset.', async (t) => {
@@ -165,7 +165,7 @@ test('filterResponse caveat returns empty if params are not a subset.', async (t
       ]
     };
 
-    let res = await sendRpcMethodWithResponse(ctrl, domain, req);
+    await sendRpcMethodWithResponse(ctrl, domain, req);
 
     // Now let's call that restricted method:
     req = {
@@ -179,12 +179,11 @@ test('filterResponse caveat returns empty if params are not a subset.', async (t
     const result = await sendRpcMethodWithResponse(ctrl, domain, req);
     t.equal(result.length, 1, 'A single item');
     t.equal(result[0], items[1], 'returns the single intersecting item');
-    t.end();
 
   } catch (err) {
     t.notOk(err, 'should not throw');
-    t.end();
   }
+  t.end();
 })
 
 test('filterResponse caveat passes through subset portion of response', async (t) => {
@@ -236,12 +235,11 @@ test('filterResponse caveat passes through subset portion of response', async (t
 
     t.ok(result, 'should succeed');
     t.deepEqual(result, [1,2,3], 'Returned the correct subset');
-    t.end();
 
   } catch (err) {
     t.notOk(err, 'should not throw');
-    t.end();
   }
+  t.end();
 })
 
 test('forceParams caveat overwrites', async (t) => {
@@ -281,7 +279,7 @@ test('forceParams caveat overwrites', async (t) => {
       ]
     };
 
-    let res = await sendRpcMethodWithResponse(ctrl, domain, req);
+    await sendRpcMethodWithResponse(ctrl, domain, req);
 
     // Now let's call that restricted method:
     req = {
@@ -293,21 +291,361 @@ test('forceParams caveat overwrites', async (t) => {
 
     t.ok(result, 'should succeed');
     t.deepEqual(result, [0,1,2,3], 'Returned the correct subset');
-    t.end();
 
   } catch (err) {
     t.notOk(err, 'should not throw');
-    t.end();
   }
+  t.end();
 })
 
-test('PermissionsController.updateCaveatsFor', async (t) => {
+test('semantic caveats', async (t) => {
   const domain = { origin: 'www.metamask.io' };
 
   const ctrl = new CapabilitiesController({
     restrictedMethods: {
       'testMethod': {
-        method: (req, res, next, end) => {
+        method: (req, res, _next, end) => {
+          res.result = req.params;
+          end();
+        }
+      }
+    },
+
+    semanticCaveatTypes: {
+      'a': {},
+      'b': {},
+    },
+
+    // All permissions automatically approved
+    requestUserApproval: async (permissionsRequest) => {
+      return permissionsRequest.permissions;
+    },
+  },
+  {
+    domains: {}
+  })
+
+  try {
+    let req = {
+      method: 'requestPermissions',
+      params: [
+        {
+          'testMethod': {
+            caveats: [
+              {
+                type: 'forceParams',
+                value: [0,1,2,3],
+                semanticType: 'a'
+              },
+            ]
+          },
+        }
+      ]
+    }
+
+    await sendRpcMethodWithResponse(ctrl, domain, req);
+
+    test('can add caveats of different semantic types', async (t) => {
+      try {
+        let req = {
+          method: 'requestPermissions',
+          params: [
+            {
+              'testMethod': {
+                caveats: [
+                  {
+                    type: 'forceParams',
+                    value: [0,1,2,3],
+                    semanticType: 'a'
+                  },
+                  {
+                    type: 'forceParams',
+                    value: [0,1,2,3],
+                    semanticType: 'b'
+                  },
+                ]
+              },
+            }
+          ]
+        }
+
+        let res = await sendRpcMethodWithResponse(ctrl, domain, req);
+        t.ok(res, 'received response');
+
+      } catch (err) {
+        t.notOk(err, 'should not throw');
+      }
+      t.end();
+    })
+
+    test('fails when adding multiple caveats of the same semantic type', async (t) => {
+      try {
+        let req = {
+          method: 'requestPermissions',
+          params: [
+            {
+              'testMethod': {
+                caveats: [
+                  {
+                    type: 'forceParams',
+                    value: [0,1,2,3],
+                    semanticType: 'a'
+                  },
+                  {
+                    type: 'forceParams',
+                    value: [0,1,2,3],
+                    semanticType: 'a'
+                  },
+                ]
+              },
+            }
+          ]
+        }
+
+        await sendRpcMethodWithResponse(ctrl, domain, req);
+        t.notOk(true, 'should have thrown')
+
+      } catch (err) {
+        t.ok(err.message.indexOf('Invalid semantic caveats.') !== -1, 'throws expected error');
+      }
+      t.end();
+    });
+  } catch (err) {
+    t.notOk(err, 'should not throw');
+  }
+  t.end();
+})
+
+test('updateCaveatFor', async (t) => {
+
+  const domain = { origin: 'www.metamask.io' };
+
+  const cav1 = {
+    type: 'forceParams',
+    value: [0,1,2,3],
+    semanticType: 'a'
+  }
+
+  const cav2 = {
+    type: 'filterResponse',
+    value: [0,1,2,3,4,5],
+    semanticType: 'c'
+  }
+
+
+  const ctrl = new CapabilitiesController({
+    restrictedMethods: {
+      'testMethod': {
+        method: (req, res, _next, end) => {
+          res.result = req.params;
+          end();
+        }
+      }
+    },
+
+    semanticCaveatTypes: {
+      'a': {},
+      'b': {},
+      'c': {},
+    },
+
+    // All permissions automatically approved
+    requestUserApproval: async (permissionsRequest) => {
+      return permissionsRequest.permissions;
+    },
+  },
+  {
+    domains: {}
+  })
+
+  try {
+
+    let req = {
+      method: 'requestPermissions',
+      params: [
+        {
+          'testMethod': {
+            caveats: [
+              { ...cav1 }, { ...cav2 }
+            ]
+          },
+        }
+      ]
+    };
+
+    await sendRpcMethodWithResponse(ctrl, domain, req);
+
+    test('updateCaveatFor throws on non-existing domain', async (t) => {
+
+      try {
+
+        ctrl.updateCaveatFor(
+          'foo.bar.xyz', 'testMethod', {
+            type: 'forceParams',
+            value: [0,1],
+            semanticType: 'a'
+          }
+        )
+
+        t.notOk(true, 'should have thrown')
+
+      } catch (err) {
+        t.ok(err, 'did throw')
+      }
+      t.end()
+    })
+
+    test('updateCaveatFor throws on non-existing method', async (t) => {
+
+      try {
+
+        ctrl.updateCaveatFor(
+          domain.origin, 'doesNotExist', {
+            type: 'forceParams',
+            value: [0,1],
+            semanticType: 'a'
+          }
+        )
+
+        t.notOk(true, 'should have thrown')
+
+      } catch (err) {
+        t.ok(err, 'did throw')
+      }
+      t.end()
+    })
+
+    test('updateCaveatFor does not alter state after throwing', async (t) => {
+
+      try {
+
+        req = {
+          method: 'testMethod',
+          params: [],
+        }
+        const result = await sendRpcMethodWithResponse(ctrl, domain, req);
+
+        t.ok(result, 'should succeed');
+        t.deepEqual(result, [0,1,2,3], 'Returned the correct subset');
+
+      } catch (err) {
+        t.notOk(err, 'should not throw')
+      }
+      t.end()
+    })
+
+    test('updateCaveatFor successfully updates caveats', async (t) => {
+
+      try {
+
+        cav1.value = [0,1,2]
+
+        ctrl.updateCaveatFor(
+          domain.origin, 'testMethod', {
+            type: 'forceParams',
+            value: cav1.value,
+            semanticType: 'a'
+          }
+        )
+
+        req = {
+          method: 'testMethod',
+          params: [],
+        }
+        const result = await sendRpcMethodWithResponse(ctrl, domain, req);
+
+        t.ok(result, 'should succeed');
+        t.deepEqual(result, [0,1,2], 'returned the correct subset');
+
+      } catch (err) {
+        t.notOk(err, 'should not throw')
+      }
+      t.end()
+    })
+
+    test('updateCaveatFor throws on non-existing caveat with valid semantic type', async (t) => {
+
+      try {
+
+        ctrl.updateCaveatFor(
+          domain.origin, 'testMethod', {
+            type: 'forceParams',
+            value: [0,1],
+            semanticType: 'b'
+          }
+        )
+
+        t.notOk(true, 'should have thrown')
+
+      } catch (err) {
+        t.ok(err, 'did throw')
+      }
+      t.end()
+    })
+
+
+    test('updateCaveatFor throws on non-existing semantic type', async (t) => {
+
+      try {
+
+        ctrl.updateCaveatFor(
+          domain.origin, 'testMethod', {
+            type: 'forceParams',
+            value: [0,1],
+            semanticType: 'doesNotExist'
+          }
+        )
+
+        t.notOk(true, 'should have thrown')
+
+      } catch (err) {
+        t.ok(err, 'did throw')
+      }
+      t.end()
+    })
+
+    test('updateCaveatFor has no side effects', async (t) => {
+
+      try {
+
+        req = {
+          method: 'testMethod',
+          params: [],
+        }
+        const result = await sendRpcMethodWithResponse(ctrl, domain, req);
+
+        t.ok(result, 'should succeed');
+        t.deepEqual(result, [0,1,2], 'Returned the correct subset');
+
+        const perms = ctrl.getPermissionsForDomain(domain.origin)
+        t.ok(perms.length === 1, 'expected number of permissions remain')
+        const { caveats } = perms[0]
+        t.ok(caveats.length === 2, 'expected number of caveats remain')
+        const c1 = caveats.find(p => p.semanticType === 'a') 
+        t.deepEqual(c1, cav1, 'caveat 1 as expected')
+        const c2 = caveats.find(p => p.semanticType === 'c')
+        t.deepEqual(c2, cav2, 'caveat 2 as expected')
+
+      } catch (err) {
+        t.notOk(err, 'should not throw')
+      }
+      t.end()
+    })
+
+  } catch (err) {
+    t.notOk(err, 'should not throw');
+  }
+  t.end();
+})
+
+test('updateCaveatFor - non-semantic controller', async (t) => {
+
+  const domain = { origin: 'www.metamask.io' };
+
+  const ctrl = new CapabilitiesController({
+    restrictedMethods: {
+      'testMethod': {
+        method: (req, res, _next, end) => {
           res.result = req.params;
           end();
         }
@@ -337,96 +675,13 @@ test('PermissionsController.updateCaveatsFor', async (t) => {
       ]
     };
 
-    let res = await sendRpcMethodWithResponse(ctrl, domain, req);
+    await sendRpcMethodWithResponse(ctrl, domain, req);
+    ctrl.updateCaveatFor() // args should not matter
 
-    test('updateCaveatsFor successfully updates caveats', async (t) => {
-
-      try {
-
-        ctrl.updateCaveatsFor(
-          domain.origin, 'testMethod', [{
-            type: 'forceParams',
-            value: [0,1,2]
-          }]
-        )
-
-        req = {
-          method: 'testMethod',
-          params: [],
-        }
-        const result = await sendRpcMethodWithResponse(ctrl, domain, req);
-
-        t.ok(result, 'should succeed');
-        t.deepEqual(result, [0,1,2], 'Returned the correct subset');
-        t.end();
-      } catch (err) {
-        t.notOk(err, 'should not throw')
-        t.end()
-      }
-    })
-
-    test('updateCaveatsFor throws on non-existing domain', async (t) => {
-
-      try {
-
-        ctrl.updateCaveatsFor(
-          'foo.bar.xyz', 'testMethod', [{
-            type: 'forceParams',
-            value: [0,1]
-          }]
-        )
-
-        t.notOk(true, 'should have thrown')
-        t.end()
-
-      } catch (err) {
-        t.ok(err, 'did throw')
-        t.end()
-      }
-    })
-
-    test('updateCaveatsFor throws on non-existing method', async (t) => {
-
-      try {
-
-        ctrl.updateCaveatsFor(
-          domain.origin, 'doesNotExist', [{
-            type: 'forceParams',
-            value: [0,1]
-          }]
-        )
-
-        t.notOk(true, 'should have thrown')
-        t.end()
-
-      } catch (err) {
-        t.ok(err, 'did throw')
-        t.end()
-      }
-    })
-
-    test('updateCaveatsFor does not alter state after throwing', async (t) => {
-
-      try {
-
-        req = {
-          method: 'testMethod',
-          params: [],
-        }
-        const result = await sendRpcMethodWithResponse(ctrl, domain, req);
-
-        t.ok(result, 'should succeed');
-        t.deepEqual(result, [0,1,2], 'Returned the correct subset');
-        t.end();
-      } catch (err) {
-        t.notOk(err, 'should not throw')
-        t.end()
-      }
-    })
-
-    t.end()
+    t.notOk(true, 'should have thrown')
   } catch (err) {
-    t.notOk(err, 'should not throw');
-    t.end();
+    t.ok(err, 'should throw');
+    t.ok(err.message.indexOf('configured for semantic') !== -1, 'throws expected error');
   }
+  t.end();
 })

--- a/test/caveats.js
+++ b/test/caveats.js
@@ -234,7 +234,7 @@ test('filterResponse caveat passes through subset portion of response', async (t
     const result = await sendRpcMethodWithResponse(ctrl, domain, req);
 
     t.ok(result, 'should succeed');
-    t.deepEqual(result, [1,2,3], 'Returned the correct subset');
+    t.deepEqual(result, [1,2,3], 'returned the correct subset');
 
   } catch (err) {
     t.notOk(err, 'should not throw');
@@ -290,7 +290,7 @@ test('forceParams caveat overwrites', async (t) => {
     const result = await sendRpcMethodWithResponse(ctrl, domain, req);
 
     t.ok(result, 'should succeed');
-    t.deepEqual(result, [0,1,2,3], 'Returned the correct subset');
+    t.deepEqual(result, [0,1,2,3], 'returned the correct subset');
 
   } catch (err) {
     t.notOk(err, 'should not throw');
@@ -298,7 +298,7 @@ test('forceParams caveat overwrites', async (t) => {
   t.end();
 })
 
-test('semantic caveats', async (t) => {
+test('named caveats', async (t) => {
   const domain = { origin: 'www.metamask.io' };
 
   const ctrl = new CapabilitiesController({
@@ -309,11 +309,6 @@ test('semantic caveats', async (t) => {
           end();
         }
       }
-    },
-
-    semanticCaveatTypes: {
-      'a': {},
-      'b': {},
     },
 
     // All permissions automatically approved
@@ -335,7 +330,7 @@ test('semantic caveats', async (t) => {
               {
                 type: 'forceParams',
                 value: [0,1,2,3],
-                semanticType: 'a'
+                name: 'a'
               },
             ]
           },
@@ -345,7 +340,7 @@ test('semantic caveats', async (t) => {
 
     await sendRpcMethodWithResponse(ctrl, domain, req);
 
-    test('can add caveats of different semantic types', async (t) => {
+    test('can add caveats with different names', async (t) => {
       try {
         let req = {
           method: 'requestPermissions',
@@ -356,12 +351,12 @@ test('semantic caveats', async (t) => {
                   {
                     type: 'forceParams',
                     value: [0,1,2,3],
-                    semanticType: 'a'
+                    name: 'a'
                   },
                   {
                     type: 'forceParams',
                     value: [0,1,2,3],
-                    semanticType: 'b'
+                    name: 'b'
                   },
                 ]
               },
@@ -378,7 +373,7 @@ test('semantic caveats', async (t) => {
       t.end();
     })
 
-    test('fails when adding multiple caveats of the same semantic type', async (t) => {
+    test('fails when adding multiple caveats with the same name', async (t) => {
       try {
         let req = {
           method: 'requestPermissions',
@@ -389,12 +384,12 @@ test('semantic caveats', async (t) => {
                   {
                     type: 'forceParams',
                     value: [0,1,2,3],
-                    semanticType: 'a'
+                    name: 'a'
                   },
                   {
                     type: 'forceParams',
                     value: [0,1,2,3],
-                    semanticType: 'a'
+                    name: 'a'
                   },
                 ]
               },
@@ -406,7 +401,7 @@ test('semantic caveats', async (t) => {
         t.notOk(true, 'should have thrown')
 
       } catch (err) {
-        t.ok(err.message.indexOf('Invalid semantic caveats.') !== -1, 'throws expected error');
+        t.ok(err.message.indexOf('Invalid caveats.') !== -1, 'throws expected error');
       }
       t.end();
     });
@@ -423,13 +418,13 @@ test('updateCaveatFor', async (t) => {
   const cav1 = {
     type: 'forceParams',
     value: [0,1,2,3],
-    semanticType: 'a'
+    name: 'a'
   }
 
   const cav2 = {
     type: 'filterResponse',
     value: [0,1,2,3,4,5],
-    semanticType: 'c'
+    name: 'c'
   }
 
 
@@ -441,12 +436,6 @@ test('updateCaveatFor', async (t) => {
           end();
         }
       }
-    },
-
-    semanticCaveatTypes: {
-      'a': {},
-      'b': {},
-      'c': {},
     },
 
     // All permissions automatically approved
@@ -483,7 +472,7 @@ test('updateCaveatFor', async (t) => {
           'foo.bar.xyz', 'testMethod', {
             type: 'forceParams',
             value: [0,1],
-            semanticType: 'a'
+            name: 'a'
           }
         )
 
@@ -503,7 +492,7 @@ test('updateCaveatFor', async (t) => {
           domain.origin, 'doesNotExist', {
             type: 'forceParams',
             value: [0,1],
-            semanticType: 'a'
+            name: 'a'
           }
         )
 
@@ -526,7 +515,7 @@ test('updateCaveatFor', async (t) => {
         const result = await sendRpcMethodWithResponse(ctrl, domain, req);
 
         t.ok(result, 'should succeed');
-        t.deepEqual(result, [0,1,2,3], 'Returned the correct subset');
+        t.deepEqual(result, [0,1,2,3], 'returned the correct subset');
 
       } catch (err) {
         t.notOk(err, 'should not throw')
@@ -544,7 +533,7 @@ test('updateCaveatFor', async (t) => {
           domain.origin, 'testMethod', {
             type: 'forceParams',
             value: cav1.value,
-            semanticType: 'a'
+            name: 'a'
           }
         )
 
@@ -563,7 +552,7 @@ test('updateCaveatFor', async (t) => {
       t.end()
     })
 
-    test('updateCaveatFor throws on non-existing caveat with valid semantic type', async (t) => {
+    test('updateCaveatFor throws on non-existing caveat with valid name', async (t) => {
 
       try {
 
@@ -571,7 +560,7 @@ test('updateCaveatFor', async (t) => {
           domain.origin, 'testMethod', {
             type: 'forceParams',
             value: [0,1],
-            semanticType: 'b'
+            name: 'b'
           }
         )
 
@@ -583,28 +572,7 @@ test('updateCaveatFor', async (t) => {
       t.end()
     })
 
-
-    test('updateCaveatFor throws on non-existing semantic type', async (t) => {
-
-      try {
-
-        ctrl.updateCaveatFor(
-          domain.origin, 'testMethod', {
-            type: 'forceParams',
-            value: [0,1],
-            semanticType: 'doesNotExist'
-          }
-        )
-
-        t.notOk(true, 'should have thrown')
-
-      } catch (err) {
-        t.ok(err, 'did throw')
-      }
-      t.end()
-    })
-
-    test('updateCaveatFor has no side effects', async (t) => {
+    test('final state after multiple updateCaveatFor calls', async (t) => {
 
       try {
 
@@ -615,16 +583,16 @@ test('updateCaveatFor', async (t) => {
         const result = await sendRpcMethodWithResponse(ctrl, domain, req);
 
         t.ok(result, 'should succeed');
-        t.deepEqual(result, [0,1,2], 'Returned the correct subset');
+        t.deepEqual(result, [0,1,2], 'returned the correct subset');
 
         const perms = ctrl.getPermissionsForDomain(domain.origin)
         t.ok(perms.length === 1, 'expected number of permissions remain')
         const { caveats } = perms[0]
         t.ok(caveats.length === 2, 'expected number of caveats remain')
-        const c1 = caveats.find(p => p.semanticType === 'a') 
-        t.deepEqual(c1, cav1, 'caveat 1 as expected')
-        const c2 = caveats.find(p => p.semanticType === 'c')
-        t.deepEqual(c2, cav2, 'caveat 2 as expected')
+        const c1 = caveats.find(p => p.name === 'a') 
+        t.deepEqual(c1, cav1, 'caveat "a" as expected')
+        const c2 = caveats.find(p => p.name === 'c')
+        t.deepEqual(c2, cav2, 'caveat "b" as expected')
 
       } catch (err) {
         t.notOk(err, 'should not throw')
@@ -638,9 +606,22 @@ test('updateCaveatFor', async (t) => {
   t.end();
 })
 
-test('updateCaveatFor - non-semantic controller', async (t) => {
+test('addCaveatFor', async (t) => {
 
   const domain = { origin: 'www.metamask.io' };
+
+  const cav1 = {
+    type: 'forceParams',
+    value: [0,1,2,3],
+    name: 'a'
+  }
+
+  const cav2 = {
+    type: 'filterResponse',
+    value: [0,1,2,3,4,5],
+    name: 'c'
+  }
+
 
   const ctrl = new CapabilitiesController({
     restrictedMethods: {
@@ -662,13 +643,14 @@ test('updateCaveatFor - non-semantic controller', async (t) => {
   })
 
   try {
+
     let req = {
       method: 'requestPermissions',
       params: [
         {
           'testMethod': {
             caveats: [
-              { type: 'forceParams', value: [0,1,2,3] },
+              { ...cav1 }, { ...cav2 }
             ]
           },
         }
@@ -676,12 +658,293 @@ test('updateCaveatFor - non-semantic controller', async (t) => {
     };
 
     await sendRpcMethodWithResponse(ctrl, domain, req);
-    ctrl.updateCaveatFor() // args should not matter
 
-    t.notOk(true, 'should have thrown')
+    test('addCaveatFor throws on non-existing domain', async (t) => {
+
+      try {
+
+        ctrl.addCaveatFor(
+          'foo.bar.xyz', 'testMethod', {
+            type: 'forceParams',
+            value: [0,1],
+            name: 'a'
+          }
+        )
+
+        t.notOk(true, 'should have thrown')
+
+      } catch (err) {
+        t.ok(err, 'did throw')
+      }
+      t.end()
+    })
+
+    test('addCaveatFor throws on non-existing method', async (t) => {
+
+      try {
+
+        ctrl.addCaveatFor(
+          domain.origin, 'doesNotExist', {
+            type: 'forceParams',
+            value: [0,1],
+            name: 'a'
+          }
+        )
+
+        t.notOk(true, 'should have thrown')
+
+      } catch (err) {
+        t.ok(err, 'did throw')
+      }
+      t.end()
+    })
+
+    test('addCaveatFor does not alter state after throwing', async (t) => {
+
+      try {
+
+        req = {
+          method: 'testMethod',
+          params: [],
+        }
+        const result = await sendRpcMethodWithResponse(ctrl, domain, req);
+
+        t.ok(result, 'should succeed');
+        t.deepEqual(result, [0,1,2,3], 'returned the correct subset');
+
+      } catch (err) {
+        t.notOk(err, 'should not throw')
+      }
+      t.end()
+    })
+
+    test('addCaveatFor successfully adds caveats', async (t) => {
+
+      try {
+
+        ctrl.addCaveatFor(
+          domain.origin, 'testMethod', {
+            type: 'forceParams',
+            value: cav1.value,
+            name: 'b'
+          }
+        )
+
+        req = {
+          method: 'testMethod',
+          params: [],
+        }
+        const result = await sendRpcMethodWithResponse(ctrl, domain, req);
+
+        t.ok(result, 'should succeed');
+        t.deepEqual(result, cav1.value, 'returned the correct subset');
+
+      } catch (err) {
+        t.notOk(err, 'should not throw')
+      }
+      t.end()
+    })
+
+    test('addCaveatFor throws on adding existing name', async (t) => {
+
+      try {
+
+        ctrl.addCaveatFor(
+          domain.origin, 'testMethod', {
+            type: 'forceParams',
+            value: [0,1],
+            name: 'b'
+          }
+        )
+
+        t.notOk(true, 'should have thrown')
+
+      } catch (err) {
+        t.ok(err, 'did throw')
+      }
+      t.end()
+    })
+
+    test('final state after multiple addCaveatFor calls', async (t) => {
+
+      try {
+
+        req = {
+          method: 'testMethod',
+          params: [],
+        }
+        const result = await sendRpcMethodWithResponse(ctrl, domain, req);
+
+        t.ok(result, 'should succeed');
+        t.deepEqual(result, cav1.value, 'returned the correct subset');
+
+        const perms = ctrl.getPermissionsForDomain(domain.origin)
+        t.ok(perms.length === 1, 'has expected number of permissions')
+        const { caveats } = perms[0]
+        t.ok(caveats.length === 3, 'has expected number of caveats')
+        let cav = caveats.find(p => p.name === 'a') 
+        t.deepEqual(cav, cav1, 'caveat "a" as expected')
+        cav = caveats.find(p => p.name === 'b') 
+        t.deepEqual(cav, { ...cav1, name: 'b' }, 'caveat "b" as expected')
+        cav = caveats.find(p => p.name === 'c')
+        t.deepEqual(cav, cav2, 'caveat "c" as expected')
+
+      } catch (err) {
+        t.notOk(err, 'should not throw')
+      }
+      t.end()
+    })
+
   } catch (err) {
-    t.ok(err, 'should throw');
-    t.ok(err.message.indexOf('configured for semantic') !== -1, 'throws expected error');
+    t.notOk(err, 'should not throw');
+  }
+  t.end();
+})
+
+test('caveat getters', async (t) => {
+
+  const domain = { origin: 'www.metamask.io' };
+
+  const cav1 = {
+    type: 'forceParams',
+    value: [0,1,2,3],
+    name: 'a'
+  }
+
+  const cav2 = {
+    type: 'filterResponse',
+    value: [0,1,2,3,4,5],
+    name: 'c'
+  }
+
+
+  const ctrl = new CapabilitiesController({
+    restrictedMethods: {
+      'testMethod': {
+        method: (req, res, _next, end) => {
+          res.result = req.params;
+          end();
+        }
+      }
+    },
+
+    // All permissions automatically approved
+    requestUserApproval: async (permissionsRequest) => {
+      return permissionsRequest.permissions;
+    },
+  },
+  {
+    domains: {}
+  })
+
+  try {
+
+    let req = {
+      method: 'requestPermissions',
+      params: [
+        {
+          'testMethod': {
+            caveats: [
+              { ...cav1 }, { ...cav2 }
+            ]
+          },
+        }
+      ]
+    };
+
+    await sendRpcMethodWithResponse(ctrl, domain, req);
+
+    test('getCaveat retrieves specific named caveat', async (t) => {
+
+      try {
+
+        const cav = ctrl.getCaveat(
+          domain.origin, 'testMethod', 'a'
+        )
+
+        t.deepEqual(cav, cav1)
+
+      } catch (err) {
+        t.notOk(err, 'should not throw')
+      }
+      t.end()
+    })
+
+    test('getCaveats retrieves all caveats', async (t) => {
+
+      try {
+
+        const caveats = ctrl.getCaveats(
+          domain.origin, 'testMethod'
+        )
+
+        t.ok(caveats.length === 2, 'has expected number of caveats')
+        let cav = caveats.find(p => p.name === 'a') 
+        t.deepEqual(cav, cav1, 'caveat "a" as expected')
+        cav = caveats.find(p => p.name === 'c')
+        t.deepEqual(cav, cav2, 'caveat "c" as expected')
+
+      } catch (err) {
+        t.notOk(err, 'should not throw')
+      }
+      t.end()
+    })
+
+    test('getting caveat(s) for unknown domain returns undefined', async (t) => {
+
+      try {
+
+        let cav = ctrl.getCaveat(
+          'not.a.known.domain', 'testMethod', 'a'
+        )
+        t.ok(cav === undefined, 'getCaveat returned undefined')
+        cav = ctrl.getCaveats(
+          'not.a.known.domain', 'testMethod'
+        )
+        t.ok(cav === undefined, 'getCaveats returned undefined')
+
+      } catch (err) {
+        t.notOk(err, 'should not throw')
+      }
+      t.end()
+    })
+
+    test('getting caveat(s) for unknown method returns undefined', async (t) => {
+
+      try {
+
+        let cav = ctrl.getCaveat(
+          domain.origin, 'unknownMethod', 'a'
+        )
+        t.ok(cav === undefined, 'getCaveat returned undefined')
+        cav = ctrl.getCaveats(
+          domain.origin, 'unknownMethod'
+        )
+        t.ok(cav === undefined, 'getCaveats returned undefined')
+
+      } catch (err) {
+        t.notOk(err, 'should not throw')
+      }
+      t.end()
+    })
+
+    test('getCaveat for unknown caveat name returns undefined', async (t) => {
+
+      try {
+
+        let cav = ctrl.getCaveat(
+          domain.origin, 'testMethod', 'unknownName'
+        )
+        t.ok(cav === undefined, 'getCaveat returned undefined')
+
+      } catch (err) {
+        t.notOk(err, 'should not throw')
+      }
+      t.end()
+    })
+
+  } catch (err) {
+    t.notOk(err, 'should not throw');
   }
   t.end();
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,12 +2,38 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.0.0":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
   integrity sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==
   dependencies:
     "@babel/highlight" "^7.0.0"
+
+"@babel/generator@^7.4.0", "@babel/generator@^7.6.3":
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.6.4.tgz#a4f8437287bf9671b07f483b76e3bb731bc97671"
+  integrity sha512-jsBuXkFoZxk0yWLyGI9llT9oiQ2FeTASmRFE32U+aaDTfoE92t78eroO7PTpU/OrYq38hlcDM6vbfLDaOLy+7w==
+  dependencies:
+    "@babel/types" "^7.6.3"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+
+"@babel/helper-function-name@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz#a0ceb01685f73355d4360c1247f582bfafc8ff53"
+  integrity sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.0.0"
+    "@babel/template" "^7.1.0"
+    "@babel/types" "^7.0.0"
+
+"@babel/helper-get-function-arity@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz#83572d4320e2a4657263734113c42868b64e49c3"
+  integrity sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==
+  dependencies:
+    "@babel/types" "^7.0.0"
 
 "@babel/helper-module-imports@^7.0.0":
   version "7.0.0"
@@ -21,6 +47,13 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz#bbb3fbee98661c569034237cc03967ba99b4f250"
   integrity sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==
 
+"@babel/helper-split-export-declaration@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz#ff94894a340be78f53f06af038b205c49d993677"
+  integrity sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==
+  dependencies:
+    "@babel/types" "^7.4.4"
+
 "@babel/highlight@^7.0.0":
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.5.0.tgz#56d11312bd9248fa619591d02472be6e8cb32540"
@@ -29,6 +62,11 @@
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^4.0.0"
+
+"@babel/parser@^7.4.3", "@babel/parser@^7.6.0", "@babel/parser@^7.6.3":
+  version "7.6.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.6.4.tgz#cb9b36a7482110282d5cb6dd424ec9262b473d81"
+  integrity sha512-D8RHPW5qd0Vbyo3qb+YjO5nvUVRTXFLQ/FsDxJU2Nqz4uB5EnUN0ZQSEYpvTIbRuttig1XbHWU5oMeQwQSAA+A==
 
 "@babel/plugin-transform-runtime@^7.5.5":
   version "7.5.5"
@@ -47,6 +85,30 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/template@^7.1.0", "@babel/template@^7.4.0":
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.6.0.tgz#7f0159c7f5012230dad64cca42ec9bdb5c9536e6"
+  integrity sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.6.0"
+    "@babel/types" "^7.6.0"
+
+"@babel/traverse@^7.4.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.6.3.tgz#66d7dba146b086703c0fb10dd588b7364cec47f9"
+  integrity sha512-unn7P4LGsijIxaAJo/wpoU11zN+2IaClkQAxcJWBNCMS6cmVh802IyLHNkAjQ0iYnRS3nnxk5O3fuXW28IMxTw==
+  dependencies:
+    "@babel/code-frame" "^7.5.5"
+    "@babel/generator" "^7.6.3"
+    "@babel/helper-function-name" "^7.1.0"
+    "@babel/helper-split-export-declaration" "^7.4.4"
+    "@babel/parser" "^7.6.3"
+    "@babel/types" "^7.6.3"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
 "@babel/types@^7.0.0":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.5.5.tgz#97b9f728e182785909aa4ab56264f090a028d18a"
@@ -55,6 +117,20 @@
     esutils "^2.0.2"
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
+
+"@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.6.0", "@babel/types@^7.6.3":
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.6.3.tgz#3f07d96f854f98e2fbd45c64b0cb942d11e8ba09"
+  integrity sha512-CqbcpTxMcpuQTMhjI37ZHVgjBkysg5icREQIEZ0eG1yCNwg3oy+5AaLiOKmjsCj6nqOsa6Hf0ObjRVwokb7srA==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@istanbuljs/nyc-config-typescript@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-0.1.3.tgz#944d15b3ebdb71f963a628daffaa25ade981bb86"
+  integrity sha512-EzRFg92bRSD1W/zeuNkeGwph0nkWf+pP2l/lYW4/5hav7RjKKBN5kV1Ix7Tvi0CMu3pC4Wi/U7rNisiJMR3ORg==
 
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
@@ -183,6 +259,18 @@ any-promise@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-0.1.0.tgz#830b680aa7e56f33451d4b049f3bd8044498ee27"
   integrity sha1-gwtoCqflbzNFHUsEnzvYBESY7ic=
+
+append-transform@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-1.0.0.tgz#046a52ae582a228bd72f58acfbe2967c678759ab"
+  integrity sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==
+  dependencies:
+    default-require-extensions "^2.0.0"
+
+archy@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
+  integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
 
 arg@^4.1.0:
   version "4.1.1"
@@ -449,10 +537,25 @@ buffer@^5.2.1:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
 
+caching-transform@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/caching-transform/-/caching-transform-3.0.2.tgz#601d46b91eca87687a281e71cef99791b0efca70"
+  integrity sha512-Mtgcv3lh3U0zRii/6qVgQODdPA4G3zhG+jtbCWj39RXuUFTMzH0vcdMtaJS1jPowd+It2Pqr6y3NJMQqOqCE2w==
+  dependencies:
+    hasha "^3.0.0"
+    make-dir "^2.0.0"
+    package-hash "^3.0.0"
+    write-file-atomic "^2.4.2"
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
+
+camelcase@^5.0.0:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
+  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -500,6 +603,15 @@ cli-width@^2.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
   integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
 
+cliui@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-5.0.0.tgz#deefcfdb2e800784aa34f46fa08e06851c7bbbc5"
+  integrity sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
+  dependencies:
+    string-width "^3.1.0"
+    strip-ansi "^5.2.0"
+    wrap-ansi "^5.1.0"
+
 clone@^2.0.0, clone@^2.1.1, clone@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
@@ -537,10 +649,27 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@2.20.0:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
+  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
+
+commondir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+  integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
+convert-source-map@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
+  integrity sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==
+  dependencies:
+    safe-buffer "~5.1.1"
 
 cookiejar@^2.1.1:
   version "2.1.2"
@@ -561,6 +690,17 @@ corser@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/corser/-/corser-2.0.1.tgz#8eda252ecaab5840dcd975ceb90d9370c819ff87"
   integrity sha1-jtolLsqrWEDc2XXOuQ2TcMgZ/4c=
+
+cp-file@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/cp-file/-/cp-file-6.2.0.tgz#40d5ea4a1def2a9acdd07ba5c0b0246ef73dc10d"
+  integrity sha512-fmvV4caBnofhPe8kOcitBwSn2f39QLjnAnGq3gO9dfd75mUytzKNZB1hde6QHunW2Rt+OwuBOMc3i1tNElbszA==
+  dependencies:
+    graceful-fs "^4.1.2"
+    make-dir "^2.0.0"
+    nested-error-stacks "^2.0.0"
+    pify "^4.0.1"
+    safe-buffer "^5.0.1"
 
 create-hash@^1.1.0, create-hash@^1.1.1, create-hash@^1.1.2, create-hash@^1.2.0:
   version "1.2.0"
@@ -592,6 +732,14 @@ cross-fetch@^2.1.0, cross-fetch@^2.1.1:
   dependencies:
     node-fetch "2.1.2"
     whatwg-fetch "2.0.4"
+
+cross-spawn@^4:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
+  integrity sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=
+  dependencies:
+    lru-cache "^4.0.1"
+    which "^1.2.9"
 
 cross-spawn@^6.0.5:
   version "6.0.5"
@@ -630,12 +778,17 @@ debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.1:
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
+
+decamelize@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+  integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
 deep-equal@~1.0.1:
   version "1.0.1"
@@ -646,6 +799,13 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+
+default-require-extensions@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-2.0.0.tgz#f5f8fbb18a7d6d50b21f641f649ebb522cfe24f7"
+  integrity sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=
+  dependencies:
+    strip-bom "^3.0.0"
 
 deferred-leveldown@~1.2.1:
   version "1.2.2"
@@ -752,6 +912,13 @@ errno@~0.1.1:
   dependencies:
     prr "~1.0.1"
 
+error-ex@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
+  integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
+  dependencies:
+    is-arrayish "^0.2.1"
+
 es-abstract@^1.13.0, es-abstract@^1.5.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
@@ -772,6 +939,11 @@ es-to-primitive@^1.2.0:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
+
+es6-error@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
+  integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -1426,6 +1598,22 @@ file-uri-to-path@1.0.0:
   resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
   integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
+find-cache-dir@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
+  integrity sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^2.0.0"
+    pkg-dir "^3.0.0"
+
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+  dependencies:
+    locate-path "^3.0.0"
+
 flat-cache@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
@@ -1453,6 +1641,14 @@ for-each@^0.3.3, for-each@~0.3.3:
   integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
   dependencies:
     is-callable "^1.1.3"
+
+foreground-child@^1.5.6:
+  version "1.5.6"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-1.5.6.tgz#4fd71ad2dfde96789b980a5c0a295937cb2f5ce9"
+  integrity sha1-T9ca0t/elnibmApcCilZN8svXOk=
+  dependencies:
+    cross-spawn "^4"
+    signal-exit "^3.0.0"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -1509,6 +1705,11 @@ gaba@^1.6.0:
     web3 "^0.20.7"
     web3-provider-engine "^15.0.3"
 
+get-caller-file@^2.0.1:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
 getpass@^0.1.1:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
@@ -1543,10 +1744,26 @@ global@~4.3.0:
     min-document "^2.19.0"
     process "~0.5.1"
 
-globals@^11.7.0:
+globals@^11.1.0, globals@^11.7.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
+
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
+  integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
+
+handlebars@^4.1.2:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.4.3.tgz#180bae52c1d0e9ec0c15d7e82a4362d662762f6e"
+  integrity sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==
+  dependencies:
+    neo-async "^2.6.0"
+    optimist "^0.6.1"
+    source-map "^0.6.1"
+  optionalDependencies:
+    uglify-js "^3.1.4"
 
 har-schema@^2.0.0:
   version "2.0.0"
@@ -1594,6 +1811,13 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
+hasha@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/hasha/-/hasha-3.0.0.tgz#52a32fab8569d41ca69a61ff1a214f8eb7c8bd39"
+  integrity sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=
+  dependencies:
+    is-stream "^1.0.1"
+
 hdkey@^0.7.0:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/hdkey/-/hdkey-0.7.1.tgz#caee4be81aa77921e909b8d228dd0f29acaee632"
@@ -1624,6 +1848,11 @@ hmac-drbg@^1.0.0:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
+
+hosted-git-info@^2.1.4:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.5.tgz#759cfcf2c4d156ade59b0b2dfabddc42a6b9c70c"
+  integrity sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==
 
 http-proxy@^1.8.1:
   version "1.17.0"
@@ -1739,6 +1968,11 @@ intersect-objects@^1.0.0:
   resolved "https://registry.yarnpkg.com/intersect-objects/-/intersect-objects-1.0.0.tgz#b7630d28994b89b0f04d44728106136549ce816e"
   integrity sha512-MS1xypHKJhWopnJgn4IbitVvt2vFy2KjINQJAPhAtDejZ+ZbMDfyPc6JsS/mWFRt9Eoku4A4usE4f2loEOoeKQ==
 
+is-arrayish@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+  integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
+
 is-callable@^1.1.3, is-callable@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.4.tgz#1e1adf219e1eeb684d691f9d6a05ff0d30a24d75"
@@ -1848,6 +2082,58 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
 
+istanbul-lib-coverage@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz#675f0ab69503fad4b1d849f736baaca803344f49"
+  integrity sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==
+
+istanbul-lib-hook@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-2.0.7.tgz#c95695f383d4f8f60df1f04252a9550e15b5b133"
+  integrity sha512-vrRztU9VRRFDyC+aklfLoeXyNdTfga2EI3udDGn4cZ6fpSXpHLV9X6CHvfoMCPtggg8zvDDmC4b9xfu0z6/llA==
+  dependencies:
+    append-transform "^1.0.0"
+
+istanbul-lib-instrument@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz#a5f63d91f0bbc0c3e479ef4c5de027335ec6d630"
+  integrity sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==
+  dependencies:
+    "@babel/generator" "^7.4.0"
+    "@babel/parser" "^7.4.3"
+    "@babel/template" "^7.4.0"
+    "@babel/traverse" "^7.4.3"
+    "@babel/types" "^7.4.0"
+    istanbul-lib-coverage "^2.0.5"
+    semver "^6.0.0"
+
+istanbul-lib-report@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-2.0.8.tgz#5a8113cd746d43c4889eba36ab10e7d50c9b4f33"
+  integrity sha512-fHBeG573EIihhAblwgxrSenp0Dby6tJMFR/HvlerBsrCTD5bkUuoNtn3gVh29ZCS824cGGBPn7Sg7cNk+2xUsQ==
+  dependencies:
+    istanbul-lib-coverage "^2.0.5"
+    make-dir "^2.1.0"
+    supports-color "^6.1.0"
+
+istanbul-lib-source-maps@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-3.0.6.tgz#284997c48211752ec486253da97e3879defba8c8"
+  integrity sha512-R47KzMtDJH6X4/YW9XTx+jrLnZnscW4VpNN+1PViSYTejLVPWv7oov+Duf8YQSPyVRUvueQqz1TcsC6mooZTXw==
+  dependencies:
+    debug "^4.1.1"
+    istanbul-lib-coverage "^2.0.5"
+    make-dir "^2.1.0"
+    rimraf "^2.6.3"
+    source-map "^0.6.1"
+
+istanbul-reports@^2.2.4:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-2.2.6.tgz#7b4f2660d82b29303a8fe6091f8ca4bf058da1af"
+  integrity sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==
+  dependencies:
+    handlebars "^4.1.2"
+
 js-sha3@0.5.5:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.5.5.tgz#baf0c0e8c54ad5903447df96ade7a4a1bca79a4a"
@@ -1875,6 +2161,16 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
+
+jsesc@^2.5.1:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
+  integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
+
+json-parse-better-errors@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
+  integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
 json-rpc-engine@^5.1.3:
   version "5.1.3"
@@ -2014,10 +2310,33 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+load-json-file@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
+  integrity sha1-L19Fq5HjMhYjT9U62rZo607AmTs=
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
+    strip-bom "^3.0.0"
+
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
+  dependencies:
+    p-locate "^3.0.0"
+    path-exists "^3.0.0"
+
 lodash.flatmap@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.flatmap/-/lodash.flatmap-4.5.0.tgz#ef8cbf408f6e48268663345305c6acc0b778702e"
   integrity sha1-74y/QI9uSCaGYzRTBcaswLd4cC4=
+
+lodash.flattendeep@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
+  integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
 lodash.unescape@4.0.1:
   version "4.0.1"
@@ -2034,10 +2353,26 @@ loglevel@^1.5.0:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.3.tgz#77f2eb64be55a404c9fd04ad16d57c1d6d6b1280"
   integrity sha512-LoEDv5pgpvWgPF4kNYuIp0qqSJVWak/dML0RY74xlzMZiT9w77teNAwKYKWBTYjlokMirg+o3jBwp+vlLrcfAA==
 
+lru-cache@^4.0.1:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 ltgt@~2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.2.1.tgz#f35ca91c493f7b73da0e07495304f17b31f87ee5"
   integrity sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=
+
+make-dir@^2.0.0, make-dir@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
+  integrity sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==
+  dependencies:
+    pify "^4.0.1"
+    semver "^5.6.0"
 
 make-error@^1.1.1:
   version "1.3.5"
@@ -2064,6 +2399,13 @@ memdown@^1.0.0:
     inherits "~2.0.1"
     ltgt "~2.2.0"
     safe-buffer "~5.1.1"
+
+merge-source-map@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/merge-source-map/-/merge-source-map-1.1.0.tgz#2fdde7e6020939f70906a68f2d7ae685e4c8c646"
+  integrity sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==
+  dependencies:
+    source-map "^0.6.1"
 
 merkle-patricia-tree@^2.1.2, merkle-patricia-tree@^2.3.2:
   version "2.3.2"
@@ -2140,7 +2482,7 @@ minimist@~0.0.1:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
   integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
-mkdirp@0.5.x, mkdirp@^0.5.1:
+mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
@@ -2177,6 +2519,16 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
+neo-async@^2.6.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
+  integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
+
+nested-error-stacks@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz#0fbdcf3e13fe4994781280524f8b96b0cdff9c61"
+  integrity sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==
+
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
@@ -2195,6 +2547,16 @@ node-fetch@^1.0.1, node-fetch@~1.7.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
+normalize-package-data@^2.3.2:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
+  integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
+  dependencies:
+    hosted-git-info "^2.1.4"
+    resolve "^1.10.0"
+    semver "2 || 3 || 4 || 5"
+    validate-npm-package-license "^3.0.1"
+
 number-to-bn@1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/number-to-bn/-/number-to-bn-1.7.0.tgz#bb3623592f7e5f9e0030b1977bd41a0c53fe1ea0"
@@ -2202,6 +2564,37 @@ number-to-bn@1.7.0:
   dependencies:
     bn.js "4.11.6"
     strip-hex-prefix "1.0.0"
+
+nyc@^14.1.1:
+  version "14.1.1"
+  resolved "https://registry.yarnpkg.com/nyc/-/nyc-14.1.1.tgz#151d64a6a9f9f5908a1b73233931e4a0a3075eeb"
+  integrity sha512-OI0vm6ZGUnoGZv/tLdZ2esSVzDwUC88SNs+6JoSOMVxA+gKMB8Tk7jBwgemLx4O40lhhvZCVw1C+OYLOBOPXWw==
+  dependencies:
+    archy "^1.0.0"
+    caching-transform "^3.0.2"
+    convert-source-map "^1.6.0"
+    cp-file "^6.2.0"
+    find-cache-dir "^2.1.0"
+    find-up "^3.0.0"
+    foreground-child "^1.5.6"
+    glob "^7.1.3"
+    istanbul-lib-coverage "^2.0.5"
+    istanbul-lib-hook "^2.0.7"
+    istanbul-lib-instrument "^3.3.0"
+    istanbul-lib-report "^2.0.8"
+    istanbul-lib-source-maps "^3.0.6"
+    istanbul-reports "^2.2.4"
+    js-yaml "^3.13.1"
+    make-dir "^2.1.0"
+    merge-source-map "^1.1.0"
+    resolve-from "^4.0.0"
+    rimraf "^2.6.3"
+    signal-exit "^3.0.2"
+    spawn-wrap "^1.4.2"
+    test-exclude "^5.2.3"
+    uuid "^3.3.2"
+    yargs "^13.2.2"
+    yargs-parser "^13.0.0"
 
 oauth-sign@~0.9.0:
   version "0.9.0"
@@ -2252,7 +2645,7 @@ opener@~1.4.0:
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.4.3.tgz#5c6da2c5d7e5831e8ffa3964950f8d6674ac90b8"
   integrity sha1-XG2ixdflgx6P+jlklQ+NZnSskLg=
 
-optimist@0.6.x:
+optimist@0.6.x, optimist@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
   integrity sha1-2j6nRob6IaGaERwybpDrFaAZZoY=
@@ -2272,10 +2665,44 @@ optionator@^0.8.2:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
+os-homedir@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
+  integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
+
 os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
+
+p-limit@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.1.tgz#aa07a788cc3151c939b5131f63570f0dd2009537"
+  integrity sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==
+  dependencies:
+    p-try "^2.0.0"
+
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
+  dependencies:
+    p-limit "^2.0.0"
+
+p-try@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
+  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
+package-hash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/package-hash/-/package-hash-3.0.0.tgz#50183f2d36c9e3e528ea0a8605dff57ce976f88e"
+  integrity sha512-lOtmukMDVvtkL84rJHI7dpTYq+0rli8N2wlnqUcBuDWCfVhRUfOmnR9SsoHFMLpACvEV60dX7rd0rFaYDZI+FA==
+  dependencies:
+    graceful-fs "^4.1.15"
+    hasha "^3.0.0"
+    lodash.flattendeep "^4.4.0"
+    release-zalgo "^1.0.0"
 
 parent-module@^1.0.0:
   version "1.0.1"
@@ -2292,6 +2719,19 @@ parse-headers@^2.0.0:
     for-each "^0.3.3"
     string.prototype.trim "^1.1.2"
 
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  integrity sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
+
+path-exists@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
+  integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
@@ -2306,6 +2746,13 @@ path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
+path-type@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
+  integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
+  dependencies:
+    pify "^3.0.0"
 
 pbkdf2@^3.0.3, pbkdf2@^3.0.9:
   version "3.0.17"
@@ -2332,6 +2779,18 @@ pify@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
   integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
+
+pify@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
+  integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
+
+pkg-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
+  integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
+  dependencies:
+    find-up "^3.0.0"
 
 portfinder@^1.0.13:
   version "1.0.23"
@@ -2387,6 +2846,11 @@ prr@~1.0.1:
   resolved "https://registry.yarnpkg.com/prr/-/prr-1.0.1.tgz#d3fc114ba06995a45ec6893f484ceb1d78f5f476"
   integrity sha1-0/wRS6BplaRexok/SEzrHXj19HY=
 
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+  integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
+
 psl@^1.1.24:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.3.0.tgz#e1ebf6a3b5564fa8376f3da2275da76d875ca1bd"
@@ -2418,6 +2882,23 @@ randombytes@^2.0.1, randombytes@^2.0.6:
   integrity sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
   dependencies:
     safe-buffer "^5.1.0"
+
+read-pkg-up@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-4.0.0.tgz#1b221c6088ba7799601c808f91161c66e58f8978"
+  integrity sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==
+  dependencies:
+    find-up "^3.0.0"
+    read-pkg "^3.0.0"
+
+read-pkg@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
+  integrity sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=
+  dependencies:
+    load-json-file "^4.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^3.0.0"
 
 readable-stream@^1.0.33:
   version "1.1.14"
@@ -2467,6 +2948,13 @@ regexpp@^2.0.1:
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
 
+release-zalgo@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/release-zalgo/-/release-zalgo-1.0.0.tgz#09700b7e5074329739330e535c5a90fb67851730"
+  integrity sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=
+  dependencies:
+    es6-error "^4.0.1"
+
 request@^2.85.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
@@ -2493,6 +2981,16 @@ request@^2.85.0:
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
+require-directory@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+  integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+
+require-main-filename@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
+  integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -2503,7 +3001,7 @@ resolve-from@^4.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
 
-resolve@^1.8.1:
+resolve@^1.10.0, resolve@^1.8.1:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
@@ -2536,6 +3034,13 @@ rimraf@2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
   integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
+
+rimraf@^2.6.2, rimraf@^2.6.3:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
   dependencies:
     glob "^7.1.3"
 
@@ -2646,12 +3151,12 @@ semaphore@>=1.0.1, semaphore@^1.0.3:
   resolved "https://registry.yarnpkg.com/semaphore/-/semaphore-1.1.0.tgz#aaad8b86b20fe8e9b32b16dc2ee682a8cd26a8aa"
   integrity sha512-O4OZEaNtkMd/K0i6js9SL+gqy0ZCBMgUvlSqHKi4IBdjhe7wB8pwztUk1BbZ1fmrvpwFrPbHzqd2w5pTcJH6LA==
 
-semver@^5.5.0, semver@^5.5.1:
+"semver@2 || 3 || 4 || 5", semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^6.1.2, semver@^6.2.0:
+semver@^6.0.0, semver@^6.1.2, semver@^6.2.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -2660,6 +3165,11 @@ semver@~5.4.1:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
   integrity sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==
+
+set-blocking@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+  integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
 set-immediate-shim@^1.0.1:
   version "1.0.1"
@@ -2693,7 +3203,7 @@ shebang-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
 
-signal-exit@^3.0.2:
+signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
@@ -2720,10 +3230,53 @@ source-map-support@^0.5.6:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map@^0.6.0:
+source-map@^0.5.0:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+  integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
+
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+spawn-wrap@^1.4.2:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/spawn-wrap/-/spawn-wrap-1.4.3.tgz#81b7670e170cca247d80bf5faf0cfb713bdcf848"
+  integrity sha512-IgB8md0QW/+tWqcavuFgKYR/qIRvJkRLPJDFaoXtLLUaVcCDK0+HeFTkmQHj3eprcYhc+gOl0aEA1w7qZlYezw==
+  dependencies:
+    foreground-child "^1.5.6"
+    mkdirp "^0.5.0"
+    os-homedir "^1.0.1"
+    rimraf "^2.6.2"
+    signal-exit "^3.0.2"
+    which "^1.3.0"
+
+spdx-correct@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.0.tgz#fb83e504445268f154b074e218c87c003cd31df4"
+  integrity sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==
+  dependencies:
+    spdx-expression-parse "^3.0.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-exceptions@^2.1.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz#2ea450aee74f2a89bfb94519c07fcd6f41322977"
+  integrity sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==
+
+spdx-expression-parse@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0"
+  integrity sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==
+  dependencies:
+    spdx-exceptions "^2.1.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-license-ids@^3.0.0:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
+  integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -2745,7 +3298,7 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
-string-width@^3.0.0:
+string-width@^3.0.0, string-width@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
   integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
@@ -2793,12 +3346,17 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-strip-ansi@^5.1.0, strip-ansi@^5.2.0:
+strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-5.2.0.tgz#8c9a536feb6afc962bdfa5b104a5091c1ad9c0ae"
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
 
 strip-hex-prefix@1.0.0:
   version "1.0.0"
@@ -2816,6 +3374,13 @@ supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
+  dependencies:
+    has-flag "^3.0.0"
+
+supports-color@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-6.1.0.tgz#0764abc69c63d5ac842dd4867e8d025e880df8f3"
+  integrity sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
   dependencies:
     has-flag "^3.0.0"
 
@@ -2847,6 +3412,16 @@ tape@^4.8.0, tape@^4.9.2:
     resumer "~0.0.0"
     string.prototype.trim "~1.1.2"
     through "~2.3.8"
+
+test-exclude@^5.2.3:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-5.2.3.tgz#c3d3e1e311eb7ee405e092dac10aefd09091eac0"
+  integrity sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==
+  dependencies:
+    glob "^7.1.3"
+    minimatch "^3.0.4"
+    read-pkg-up "^4.0.0"
+    require-main-filename "^2.0.0"
 
 text-table@^0.2.0:
   version "0.2.0"
@@ -2948,6 +3523,14 @@ typescript@^3.5.1:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
   integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
+uglify-js@^3.1.4:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.6.1.tgz#ae7688c50e1bdcf2f70a0e162410003cf9798311"
+  integrity sha512-+dSJLJpXBb6oMHP+Yvw8hUgElz4gLTh82XuX68QiJVTXaE5ibl6buzhNkQdYhBlIhozWOC9ge16wyRmjG4TwVQ==
+  dependencies:
+    commander "2.20.0"
+    source-map "~0.6.1"
+
 union@~0.4.3:
   version "0.4.6"
   resolved "https://registry.yarnpkg.com/union/-/union-0.4.6.tgz#198fbdaeba254e788b0efcb630bc11f24a2959e0"
@@ -3001,6 +3584,14 @@ v8-compile-cache@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
   integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
+
+validate-npm-package-license@^3.0.1:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
+  integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
+  dependencies:
+    spdx-correct "^3.0.0"
+    spdx-expression-parse "^3.0.0"
 
 verror@1.10.0:
   version "1.10.0"
@@ -3060,7 +3651,12 @@ whatwg-fetch@>=0.10.0:
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
   integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
-which@^1.2.9:
+which-module@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
+  integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
+
+which@^1.2.9, which@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
   integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
@@ -3077,10 +3673,28 @@ wordwrap@~1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
+wrap-ansi@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
+  integrity sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
+  dependencies:
+    ansi-styles "^3.2.0"
+    string-width "^3.0.0"
+    strip-ansi "^5.0.0"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+write-file-atomic@^2.4.2:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.3.tgz#1fd2e9ae1df3e75b8d8c367443c692d4ca81f481"
+  integrity sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    signal-exit "^3.0.2"
 
 write@1.0.3:
   version "1.0.3"
@@ -3134,6 +3748,40 @@ xtend@~2.1.1:
   integrity sha1-bv7MKk2tjmlixJAbM3znuoe10os=
   dependencies:
     object-keys "~0.4.0"
+
+y18n@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
+  integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
+
+yargs-parser@^13.0.0, yargs-parser@^13.1.1:
+  version "13.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-13.1.1.tgz#d26058532aa06d365fe091f6a1fc06b2f7e5eca0"
+  integrity sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs@^13.2.2:
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.0.tgz#4c657a55e07e5f2cf947f8a366567c04a0dedc83"
+  integrity sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==
+  dependencies:
+    cliui "^5.0.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^13.1.1"
 
 yn@^3.0.0:
   version "3.1.1"


### PR DESCRIPTION
This PR introduces a `name` property to caveats to enable the identification of specific caveats for the purpose of updating them.

Caveat names have the following properties:
- they must be of type `string`
- they must be unique per permission

Adds methods to `CapabilitiesController` for the purpose of:
- getting all caveats for a particular permission
- getting a specific named caveat for a particular permission
- adding a caveat to a particular permission
- updating the value of a specific named caveat for a particular permission
- validating a set of caveats, specifically with a mind to enforcing unique names

As the new methods are not middleware methods, we should only call them with care from the extension background. I am open to creating middleware methods if necessary. I would appreciate feedback on what these methods do to the security model of `rpc-cap`. I'm not so worried about the `addCaveatFor` method, but I'm wondering if the existence of an `updateCaveatFor` method messes with our assumptions about `rpc-cap`. The solution to this problem would simply be to re-request the permission, and we'd still make good use of almost all additions in this PR in that case.