### PR TITLE
fix filterParams subset bug

### DIFF
--- a/src/caveats.ts
+++ b/src/caveats.ts
@@ -17,7 +17,8 @@ export type ICaveatFunctionGenerator = (caveat:IOcapLdCaveat) => ICaveatFunction
 export const filterParams: ICaveatFunctionGenerator = function filterParams(serialized: IOcapLdCaveat) {
   const { value } = serialized;
   return (req, res, next, end) => {
-    const permitted = isSubset(req.params, value);
+    // are the params a strict subset of the caveat value?
+    const permitted = isSubset(value, req.params);
 
     if (!permitted) {
       res.error = unauthorized({ data: req });


### PR DESCRIPTION
Add `filterParams` caveat. May be unnecessary with the existence of `requireParams` caveat, but leaving this pull request open in case we want it later.