### PR TITLE
Rename filterParams to requireParams

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Currently all supported caveats can be found in the [Caveats.ts file](./src/cave
 
 Right now the supported caveat types are simple, to demonstrate the concept:
 
-- filterParams: Ensures that the method can only be called with a superset of some hard-defined parametersa.
+- requireParams: Ensures that the method can only be called with a superset of some hard-defined parametersa.
 - filterResponse: Ensures that the response will only include explicitly permitted values in it (if an array).
 - forceParams: Overwrites the params of all calls to the method with a specified list of params.
 
@@ -178,7 +178,7 @@ engine.handle({
       sendEmail: {
         caveats: [
           {
-            type: 'filterParams',
+            type: 'requireParams',
             value: {
               to: 'only@my-address.com',
             }

--- a/index.ts
+++ b/index.ts
@@ -15,7 +15,7 @@ import { BaseController } from 'gaba';
 
 import {
   ICaveatFunction,
-  filterParams,
+  requireParams,
   filterResponse,
   forceParams,
   ICaveatFunctionGenerator,
@@ -95,7 +95,7 @@ export class CapabilitiesController extends BaseController<any, any> implements 
   private restrictedMethods: RestrictedMethodMap;
   private requestUserApproval: UserApprovalPrompt;
   private internalMethods: { [methodName: string]: AuthenticatedJsonRpcMiddleware }
-  private caveats: { [ name: string]: ICaveatFunctionGenerator } = { filterParams, filterResponse, forceParams };
+  private caveats: { [ name: string]: ICaveatFunctionGenerator } = { requireParams, filterResponse, forceParams };
   private methodPrefix: string;
   private engine: JsonRpcEngine | undefined;
 

--- a/src/caveats.ts
+++ b/src/caveats.ts
@@ -11,10 +11,9 @@ export type ICaveatFunction = JsonRpcMiddleware;
 export type ICaveatFunctionGenerator = (caveat:IOcapLdCaveat) => ICaveatFunction;
 
 /*
- * Filters params shallowly.
- * MVP caveats with lots of room for enhancement later.
+ * Require that the request params match those specified by the caveat value.
  */
-export const filterParams: ICaveatFunctionGenerator = function filterParams(serialized: IOcapLdCaveat) {
+export const requireParams: ICaveatFunctionGenerator = function requireParams(serialized: IOcapLdCaveat) {
   const { value } = serialized;
   return (req, res, next, end) => {
     const permitted = isSubset(req.params, value);
@@ -30,8 +29,6 @@ export const filterParams: ICaveatFunctionGenerator = function filterParams(seri
 
 /*
  * Filters array results shallowly.
- * MVP caveat for signing in with accounts.
- * Lots of room for enhancement later.
  */
 export const filterResponse: ICaveatFunctionGenerator = function filterResponse(serialized: IOcapLdCaveat) {
   const { value } = serialized;
@@ -49,7 +46,7 @@ export const filterResponse: ICaveatFunctionGenerator = function filterResponse(
 }
 
 /*
- * Forces the method to be called with given params
+ * Forces the method to be called with given params.
  */
 export const forceParams: ICaveatFunctionGenerator = function forceParams(serialized: IOcapLdCaveat) {
   const { value } = serialized;

--- a/test/caveats.js
+++ b/test/caveats.js
@@ -6,7 +6,7 @@ const sendRpcMethodWithResponse = require('./lib/utils').sendRpcMethodWithRespon
 
 const UNAUTHORIZED_CODE = require('eth-json-rpc-errors').ERROR_CODES.provider.unauthorized
 
-test('filterParams caveat throws if params are not a subset.', async (t) => {
+test('requireParams caveat throws if caveat value is not a subset of params.', async (t) => {
   const domain = { origin: 'www.metamask.io' };
 
   const ctrl = new CapabilitiesController({
@@ -25,7 +25,7 @@ test('filterParams caveat throws if params are not a subset.', async (t) => {
     requestUserApproval: async (permissionsRequest) => {
       const perms = permissionsRequest.permissions;
       perms.write.caveats = [
-        { type: 'filterParams', value: ['foo', { bar: 'baz' }] },
+        { type: 'requireParams', value: ['foo', { bar: 'baz' }] },
       ]
       return perms;
     },
@@ -65,7 +65,7 @@ test('filterParams caveat throws if params are not a subset.', async (t) => {
   t.end();
 })
 
-test('filterParams caveat passes through if params are a subset.', async (t) => {
+test('requireParams caveat passes through if caveat value is a subset of params.', async (t) => {
   const domain = { origin: 'www.metamask.io' };
   const params = [
     'foo',
@@ -87,7 +87,7 @@ test('filterParams caveat passes through if params are a subset.', async (t) => 
     requestUserApproval: async (permissionsRequest) => {
       const perms = permissionsRequest.permissions;
       perms.write.caveats = [
-        { type: 'filterParams', value: ['foo', { bar: 'baz' }] },
+        { type: 'requireParams', value: ['foo', { bar: 'baz' }] },
       ]
       return perms;
     },
@@ -106,7 +106,7 @@ test('filterParams caveat passes through if params are a subset.', async (t) => 
       ]
     };
 
-    let res = await sendRpcMethodWithResponse(ctrl, domain, req);
+    await sendRpcMethodWithResponse(ctrl, domain, req);
 
     // Now let's call that restricted method:
     req = {
@@ -223,7 +223,7 @@ test('filterResponse caveat passes through subset portion of response', async (t
       ]
     };
 
-    let res = await sendRpcMethodWithResponse(ctrl, domain, req);
+    await sendRpcMethodWithResponse(ctrl, domain, req);
 
     // Now let's call that restricted method:
     req = {


### PR DESCRIPTION
During the security audit, there was some confusion caused by the name of `filterParams`. Its action is closer in meaning to `requireParams` since it is intended to enforce that **some or all** params have a specific value, **not** that all params always have to match some given value.

Thus, this PR renames `filterParams` to `requireParams` and clarifies its meaning in comments and the readme.