### PR TITLE
Add events for granting permission success/failure

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -410,7 +410,7 @@ export class CapabilitiesController extends BaseController<any, any> implements 
     res.result = this.getPermissionsForDomain(domain);
     end();
     // indicate successful granting of permissions to the client
-    this.events.emit(requestId, res.result);
+    requestId && this.events.emit(requestId, res.result);
   }
 
   getDomains (): RpcCapDomainRegistry {
@@ -849,7 +849,7 @@ export class CapabilitiesController extends BaseController<any, any> implements 
       end(reason);
       // indicated failure to grant permission for the convenience
       // of the client
-      this.events.emit(id, null);
+      id && this.events.emit(id, null);
     })
     .finally(() => {
       // Delete the request object

--- a/package.json
+++ b/package.json
@@ -20,6 +20,18 @@
     "type": "git",
     "url": "git+https://github.com/MetaMask/rpc-cap.git"
   },
+  "dependencies": {
+    "clone": "^2.1.2",
+    "eth-json-rpc-errors": "^2.0.0",
+    "fast-deep-equal": "^2.0.1",
+    "gaba": "^1.6.0",
+    "intersect-objects": "^1.0.0",
+    "is-subset": "^0.1.1",
+    "json-rpc-engine": "^5.1.3",
+    "obs-store": "^4.0.3",
+    "safe-event-emitter": "^1.0.1",
+    "uuid": "^3.3.2"
+  },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^0.1.3",
     "@types/node": "^12.0.7",
@@ -32,16 +44,5 @@
     "tape": "^4.9.2",
     "ts-node": "^8.2.0",
     "typescript": "^3.5.1"
-  },
-  "dependencies": {
-    "clone": "^2.1.2",
-    "eth-json-rpc-errors": "^2.0.0",
-    "fast-deep-equal": "^2.0.1",
-    "gaba": "^1.6.0",
-    "intersect-objects": "^1.0.0",
-    "is-subset": "^0.1.1",
-    "json-rpc-engine": "^5.1.3",
-    "obs-store": "^4.0.3",
-    "uuid": "^3.3.2"
   }
 }

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -87,10 +87,11 @@ export interface RestrictedMethodMap {
 }
 
 export interface RpcCapInterface {
+  once: (event: string, handler: (...args: any[]) => void) => void;
   getPermissionsForDomain: (domain: string) => IOcapLdCapability[];
   getPermission: (domain: string, method: string) => IOcapLdCapability | undefined;
   getPermissionsRequests: () => IPermissionsRequest[];
-  grantNewPermissions (domain: string, approved: IRequestedPermissions, res: JsonRpcResponse<any>, end: JsonRpcEngineEndCallback, granter?: string): void;
+  grantNewPermissions (requestId: string, domain: string, approved: IRequestedPermissions, res: JsonRpcResponse<any>, end: JsonRpcEngineEndCallback, granter?: string): void;
   getDomains: () => RpcCapDomainRegistry;
   setDomains: (domains: RpcCapDomainRegistry) => void;
   getDomainSettings: (domain: string) => RpcCapDomainEntry;
@@ -100,6 +101,14 @@ export interface RpcCapInterface {
   removePermissionsFor: (domain: string, permissionsToRemove: IOcapLdCapability[]) => void;
   createBoundMiddleware: (domain: string) => PermittedJsonRpcMiddleware;
   createPermissionedEngine: (domain: string) => JsonRpcEngine;
+  validateCaveats: (caveats: IOcapLdCaveat[]) => boolean;
+  validateCaveat: (caveat: IOcapLdCaveat) => boolean;
+  getCaveats: (domainName: string, methodName: string) => IOcapLdCaveat[] | void;
+  getCaveat: (domainName: string, methodName: string, caveatName: string) => IOcapLdCaveat | void;
+  addCaveatFor: (domainName: string, methodName: string, caveat: IOcapLdCaveat) => void;
+  updateCaveatFor: (domainName: string, methodName: string, caveatName: string, caveatValue: any) => void;
+
+
 
   // Injected permissions-handling methods:
   providerMiddlewareFunction: AuthenticatedJsonRpcMiddleware;


### PR DESCRIPTION
This addresses the following shortcoming in the permissions approval and granting flow:

The client passes in the `requestUserApproval` function, but won't know if the permissions were successfully granted unless it intercepts the RPC response. In the extension's controller architecture, I saw no easy way to accomplish this.

This PR adds an internal `SafeEventEmitter` to the `CapabilitiesController`. Now, after a permission request is approved, `rpc-cap` will either emit `(permissionRequestId, approvedPermissions)` on successfully granting those permissions or `(permissionsRequestId, null)` if it fails to grant those permissions.

Since we want to allow the option of modifying a permissions request in the client before it is approved - potentially adding caveats which may or may not be valid - we cannot know if granting the permissions will succeed before the user approves them.