### PR TITLE
Fix faulty errors in provider middleware

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -183,14 +183,18 @@ export class CapabilitiesController extends BaseController<any, any> implements 
       return this.internalMethods[methodName](domain, req, res, next, end);
     }
 
+    // if the method also is not a restricted method, the method does not exist
+    if (!this.restrictedMethods[methodName]) {
+      res.error = methodNotFound({ data: req });
+      return end(res.error);
+    }
+
     let permission;
     try {
       permission = this.getPermission(domain.origin, methodName);
     } catch (err) {
-      res.error = {
-        message: err.message,
-        code: 1,
-      };
+      // unexpected internal error
+      res.error = internalError({ data: err });
       return end(res.error);
     }
 

--- a/index.ts
+++ b/index.ts
@@ -184,7 +184,7 @@ export class CapabilitiesController extends BaseController<any, any> implements 
     }
 
     // if the method also is not a restricted method, the method does not exist
-    if (!this.restrictedMethods[methodName]) {
+    if (!this.getMethodKeyFor(methodName)) {
       res.error = methodNotFound({ data: req });
       return end(res.error);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rpc-cap",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
- Return `methodNotFound` error instead of `unauthorized` if a method does not exist, before attempting to retrieve the permission for it
- Stop returning non-standard error if `getPermissions` throws unexpectedly
- Version bump: `1.0.0` -> `1.0.1`