### PR TITLE
2.0.0: Store permissions by method key, various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ This module is written in TypeScript, and so type definitions can be found in [o
 
 Here is a more detailed look at the methods that are added to a JSON-RPC service using this module.
 
-#### getPermissions() => IOcapLdCapability[]
+#### getPermissions() => IGrantedPermissions
 
 ```typescript
 engine.handle({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rpc-cap",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rpc-cap",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -49,8 +49,13 @@ export interface UserApprovalPrompt {
   (permissionsRequest: IPermissionsRequest): Promise<IRequestedPermissions>;
 }
 
+/**
+ * The format in which permissions are stored, keyed by 'parentCapability', i.e. 'methodName'.
+ */
+export interface IGrantedPermissions { [parentCapability: string]: IOcapLdCapability }
+
 export interface RpcCapDomainEntry {
-  permissions: IOcapLdCapability[];
+  permissions: IGrantedPermissions;
 }
 
 type IOriginString = string;
@@ -87,7 +92,7 @@ export interface RestrictedMethodMap {
 }
 
 export interface RpcCapInterface {
-  getPermissionsForDomain: (domain: string) => IOcapLdCapability[];
+  getPermissionsForDomain: (domain: string) => IGrantedPermissions;
   getPermission: (domain: string, method: string) => IOcapLdCapability | undefined;
   getPermissionsRequests: () => IPermissionsRequest[];
   grantNewPermissions (domain: string, approved: IRequestedPermissions, res: JsonRpcResponse<any>, end: JsonRpcEngineEndCallback, granter?: string): void;
@@ -97,7 +102,7 @@ export interface RpcCapInterface {
   getOrCreateDomainSettings: (domain: string) => RpcCapDomainEntry;
   setDomain: (domain: string, settings: RpcCapDomainEntry) => void;
   addPermissionsFor: (domainName: string, newPermissions: { [methodName: string]: IOcapLdCapability }) => void;
-  removePermissionsFor: (domain: string, permissionsToRemove: IOcapLdCapability[]) => void;
+  removePermissionsFor: (domain: string, permissionsToRemove: string[]) => void;
   createBoundMiddleware: (domain: string) => PermittedJsonRpcMiddleware;
   createPermissionedEngine: (domain: string) => JsonRpcEngine;
 

--- a/test/caveats.js
+++ b/test/caveats.js
@@ -586,8 +586,8 @@ test('updateCaveatFor', async (t) => {
         t.deepEqual(result, [0,1,2], 'returned the correct subset');
 
         const perms = ctrl.getPermissionsForDomain(domain.origin)
-        t.ok(perms.length === 1, 'expected number of permissions remain')
-        const { caveats } = perms[0]
+        t.ok(Object.keys(perms).length === 1, 'expected number of permissions remain')
+        const { caveats } = perms['testMethod']
         t.ok(caveats.length === 2, 'expected number of caveats remain')
         const c1 = caveats.find(p => p.name === 'a') 
         t.deepEqual(c1, cav1, 'caveat "a" as expected')
@@ -779,8 +779,8 @@ test('addCaveatFor', async (t) => {
         t.deepEqual(result, cav1.value, 'returned the correct subset');
 
         const perms = ctrl.getPermissionsForDomain(domain.origin)
-        t.ok(perms.length === 1, 'has expected number of permissions')
-        const { caveats } = perms[0]
+        t.ok(Object.keys(perms).length === 1, 'has expected number of permissions')
+        const { caveats } = perms['testMethod']
         t.ok(caveats.length === 3, 'has expected number of caveats')
         let cav = caveats.find(p => p.name === 'a') 
         t.deepEqual(cav, cav1, 'caveat "a" as expected')

--- a/test/forwarding.js
+++ b/test/forwarding.js
@@ -153,12 +153,12 @@ test('requesting restricted method with permission is called', async (t) => {
   {
     domains: {
       'login.metamask.io': {
-        permissions: [
-          {
+        permissions: {
+          eth_write: {
             parentCapability: 'eth_write',
             date: '0',
           }
-        ]
+        }
       }
     }
   })

--- a/test/getPermissions.js
+++ b/test/getPermissions.js
@@ -20,7 +20,7 @@ const arbitraryCaps = [
 ]
 
 test('getPermissions with none returns empty object', async (t) => {
-  const expected = []
+  const expected = {}
 
   const ctrl = new CapabilitiesController({
     requestUserApproval: noop,

--- a/test/requestPermissions.js
+++ b/test/requestPermissions.js
@@ -7,7 +7,7 @@ const USER_REJECTION_CODE = rpcErrors.ERROR_CODES.provider.userRejectedRequest
 const INVALID_REQUEST_CODE = rpcErrors.ERROR_CODES.rpc.invalidRequest
 
 test('requestPermissions with user rejection creates no permissions', async (t) => {
-  const expected = []
+  const expected = {}
 
   const ctrl = new CapabilitiesController({
     requestUserApproval: () => Promise.resolve({}),
@@ -44,7 +44,7 @@ test('requestPermissions with user rejection creates no permissions', async (t) 
 })
 
 test('requestPermissions with invalid requested permissions object fails', async (t) => {
-  const expected = []
+  const expected = {}
 
   const ctrl = new CapabilitiesController({
     requestUserApproval: () => Promise.resolve({}),
@@ -115,10 +115,10 @@ test('requestPermissions with user approval creates permission', async (t) => {
   }
 
   try {
-    let res = await sendRpcMethodWithResponse(ctrl, domain, req);
+    await sendRpcMethodWithResponse(ctrl, domain, req);
     const endState = ctrl.state
     const perms = endState.domains[domain.origin].permissions;
-    t.equal(perms[0].parentCapability, 'restricted', 'permission added.')
+    t.ok(perms.hasOwnProperty('restricted'), 'permission added.')
     t.end()
 
   } catch (error) {


### PR DESCRIPTION
`IOcapLdCapability` objects are now stored by method keys under the `permissions` key inside domain objects.

Fixes #51, Fixes #52, Fixes #67, Fixes #68 