### PR TITLE
Fix null typechecks, TypeScript types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,8 @@ module.exports = {
 
   plugins: ['@typescript-eslint'],
 
+  ignorePatterns: ['scripts/'],
+
   extends: [
     '@metamask/eslint-config',
     '@metamask/eslint-config/config/typescript',

--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,0 @@
-diagrams
-*.png
-*.graffle
-.DS_Store
-.circleci
-.python-version
-.nyc_output
-*.log

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # `rpc-cap` [![CircleCI](https://circleci.com/gh/MetaMask/rpc-cap.svg?style=svg)](https://circleci.com/gh/MetaMask/rpc-cap)
+
 ## JSON RPC Capabilities Middleware 
 
 A module for managing basic [capability-based security](https://en.wikipedia.org/wiki/Capability-based_security) over a [JSON-RPC API](https://www.jsonrpc.org/) as a middleware function for [json-rpc-engine](https://www.npmjs.com/package/json-rpc-engine), to instantly add a user-consent based permissions system on top of any JSON-RPC API.
@@ -6,6 +7,7 @@ A module for managing basic [capability-based security](https://en.wikipedia.org
 Requires that you are able to authenticate a requesting `domain`, which can be any unique string you use to identify a remote entity, be it a user ID whose cookie you've verified, or a public key that you've challenged:
 
 ## Minimal Example
+
 A fairly minimal server example, hosted over a [socket.io-like](https://www.npmjs.com/package/socket.io) server API.
 
 ```typescript
@@ -96,6 +98,7 @@ engine.handle({
    **/
 })
 ```
+
 If the `method` requested is `getPermissions` (optionally preceded by `methodPrefix`), the response will be an array of capability objects, which each represent the permission to call a function, with the key `parentCapability` to indicate the restricted method's name.
 
 ```typescript
@@ -126,6 +129,7 @@ export type IOcapLdCaveat = {
   value?: any;
 }
 ```
+
 Of particular interest will be the `caveats` array, which will eventually be customizable by the platform, and describe possible limitations being imposed on the way that particular method is called:
 
 ##### Currently Supported Caveats
@@ -317,6 +321,7 @@ interface IOcapLdCapability {
   proof?: IOcapLdProof;
 }
 ```
+
 A promise-returning function representing
 
 You can see our `IMethodRequest` objects, along with our internal permissions storage, are in a schema based on the [ocap-ld](https://w3c-ccg.github.io/ocap-ld/) proposal, which may allow us to add signatures to these permissions in the future. That would allow:
@@ -325,7 +330,6 @@ You can see our `IMethodRequest` objects, along with our internal permissions st
 - Unauthenticated, stateless connections, which are authenticated by signed "invocations" by the keys that these permissions would be signed "to".
 
 None of these features are used yet, but we've used this schema internally to provide an interesting possible future path for the project.
-
 
 ## A more detailed Example
 

--- a/index.ts
+++ b/index.ts
@@ -541,9 +541,9 @@ export class CapabilitiesController extends BaseController<any, any> implements 
   validateCaveat (caveat: IOcapLdCaveat): boolean {
 
     if (
-      typeof caveat !== 'object' || Array.isArray(caveat) ||
+      !caveat || typeof caveat !== 'object' || Array.isArray(caveat) ||
       !caveat.type || typeof caveat.type !== 'string' ||
-      caveat.name === '' ||
+      caveat.name === '' || // name may be omitted, but not empty
       caveat.name && typeof caveat.name !== 'string'
 
     ) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rpc-cap",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "rm -rf dist && tsc",
+    "build": "yarn build:typescript && yarn build:types",
+    "build:typescript": "rm -rf dist && tsc",
+    "build:types": "./scripts/copyDistTypes.sh",
     "build:watch": "yarn build && tsc -w",
     "lint": "./node_modules/.bin/eslint index.ts",
     "lint:fix": "./node_modules/.bin/eslint index.ts --fix",
@@ -45,5 +47,8 @@
     "json-rpc-engine": "^5.1.8",
     "obs-store": "^4.0.3",
     "uuid": "^3.3.2"
-  }
+  },
+  "files": [
+    "dist/"
+  ]
 }

--- a/scripts/copyDistTypes.sh
+++ b/scripts/copyDistTypes.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -u
+set -o pipefail
+
+# constants
+
+NO_DIST_MSG='Please run `yarn build:typescript` before continuing.'
+
+DIST='dist'
+DIST_SRC='dist/src'
+DIST_TYPES='dist/src/@types'
+
+SRC_TYPES='src/@types'
+
+# error func
+function abort {
+  local message="${1}"
+
+  printf "ERROR: %s\\n" "${message}" >&2
+
+  exit 1
+}
+
+function main {
+
+  if [[ ! -d "${DIST}" || ! -d "${DIST_SRC}" ]]; then
+      abort "$NO_DIST_MSG"
+  fi
+
+  cp -r "${SRC_TYPES}" "${DIST_SRC}"
+}
+
+main

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -1,5 +1,3 @@
-/// <reference path="./ocap-ld.d.ts" />
-
 import { JsonRpcRequest, JsonRpcResponse, JsonRpcError, JsonRpcEngine } from 'json-rpc-engine';
 import { IOcapLdCapability, IOcapLdCaveat } from './ocap-ld';
 import { JsonRpcMiddleware, JsonRpcEngineEndCallback, JsonRpcEngineNextCallback } from 'json-rpc-engine';

--- a/src/@types/uuid.d.ts
+++ b/src/@types/uuid.d.ts
@@ -1,2 +1,0 @@
-
-export type v4 = () => string;

--- a/src/caveats.ts
+++ b/src/caveats.ts
@@ -1,5 +1,3 @@
-/// <reference path="./@types/is-subset.d.ts" />
-
 import { JsonRpcMiddleware } from 'json-rpc-engine';
 import { isSubset } from './@types/is-subset';
 import { IOcapLdCaveat } from './@types/ocap-ld'

--- a/test/caveats.js
+++ b/test/caveats.js
@@ -12,7 +12,7 @@ test('requireParams caveat throws if caveat value is not a subset of params.', a
   const ctrl = new CapabilitiesController({
     restrictedMethods: {
       'write': {
-        method: (req, res, next, end) => {
+        method: (req, res, _next, end) => {
           const params = req.params;
           res.result = params;
           end();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src/**/*.ts", "test/*.ts", "index.ts"],
+	"include": ["src/", "index.ts"],
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
- **Includes patch version bump**
- **PENDING**
  - https://github.com/MetaMask/eth-json-rpc-errors/pull/5
- TypeScript types fixup and `dist` type fix
  - `tsc` doesn't handle relative type imports very well; added a script to handle this
- For typechecks of the form `/typeof .+ (===|!==) 'object'/`, adds a check if the tested variable is truthy or falsy as appropriate.