### PR TITLE
Fix sourcemaps and permission request validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rpc-cap",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rpc-cap",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "noUnusedParameters": true,
     "outDir": "dist",
     "removeComments": false,
-    "inlineSourceMap": true,
+    "sourceMap": true,
     "inlineSources": true,
     "strict": true,
     "target": "es6"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "noUnusedParameters": true,
     "outDir": "dist",
     "removeComments": false,
-    "sourceMap": true,
+    "inlineSourceMap": true,
+    "inlineSources": true,
     "strict": true,
     "target": "es6"
   }


### PR DESCRIPTION
- **Includes patch version bump:** `1.0.x` -> `1.1.0`
  - A minor bump because an error is returned at an earlier stage in the permissions request process; see below.
- Rejects permissions requests for unknown methods before `requestUserApproval` is called
  - Keeps the check and continues to throw the same error in `grantNewPermissions`, as the requested permissions can be modified by the consumer during `requestUserApproval`
- Fixes sourcemaps by setting `inlineSources: true`