### PR TITLE
add limitResponseLength caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,9 @@ Currently all supported caveats can be found in the [Caveats.ts file](./src/cave
 
 Right now the supported caveat types are simple, to demonstrate the concept:
 
-- requireParams: Ensures that the method can only be called with a superset of some hard-defined parametersa.
+- requireParams: Ensures that the method can only be called with a superset of some hard-defined parameters.
 - filterResponse: Ensures that the response will only include explicitly permitted values in it (if an array).
+- limitResponse: Ensures that the response will only include a maximum number of entries as defined by the value (if an array).
 - forceParams: Overwrites the params of all calls to the method with a specified list of params.
 
 Some caveat types we are looking forward to supporting eventually:

--- a/index.ts
+++ b/index.ts
@@ -18,7 +18,7 @@ import {
   ICaveatFunction,
   requireParams,
   filterResponse,
-  limitResponse,
+  limitResponseLength,
   forceParams,
   ICaveatFunctionGenerator,
 } from './src/caveats';
@@ -99,7 +99,7 @@ export class CapabilitiesController extends BaseController<any, any> implements 
   private restrictedMethods: RestrictedMethodMap;
   private requestUserApproval: UserApprovalPrompt;
   private internalMethods: { [methodName: string]: AuthenticatedJsonRpcMiddleware };
-  private caveats: { [ name: string]: ICaveatFunctionGenerator } = { requireParams, filterResponse, limitResponse, forceParams };
+  private caveats: { [ name: string]: ICaveatFunctionGenerator } = { requireParams, filterResponse, limitResponseLength, forceParams };
   private methodPrefix: string;
   private engine: JsonRpcEngine | undefined;
 

--- a/index.ts
+++ b/index.ts
@@ -18,6 +18,7 @@ import {
   ICaveatFunction,
   requireParams,
   filterResponse,
+  limitResponse,
   forceParams,
   ICaveatFunctionGenerator,
 } from './src/caveats';
@@ -98,7 +99,7 @@ export class CapabilitiesController extends BaseController<any, any> implements 
   private restrictedMethods: RestrictedMethodMap;
   private requestUserApproval: UserApprovalPrompt;
   private internalMethods: { [methodName: string]: AuthenticatedJsonRpcMiddleware };
-  private caveats: { [ name: string]: ICaveatFunctionGenerator } = { requireParams, filterResponse, forceParams };
+  private caveats: { [ name: string]: ICaveatFunctionGenerator } = { requireParams, filterResponse, limitResponse, forceParams };
   private methodPrefix: string;
   private engine: JsonRpcEngine | undefined;
 

--- a/src/caveats.ts
+++ b/src/caveats.ts
@@ -43,6 +43,22 @@ export const filterResponse: ICaveatFunctionGenerator = function filterResponse 
 };
 
 /*
+ * Limits array results to a specific integer length.
+ */
+export const limitResponse: ICaveatFunctionGenerator = function limitResponse (serialized: IOcapLdCaveat) {
+  const { value } = serialized;
+  return (_req, res, next, _end): void => {
+
+    next((done) => {
+      if (Array.isArray(res.result)) {
+        res.result = res.result.slice(0, value);
+      }
+      done();
+    });
+  };
+};
+
+/*
  * Forces the method to be called with given params.
  */
 export const forceParams: ICaveatFunctionGenerator = function forceParams (serialized: IOcapLdCaveat) {

--- a/src/caveats.ts
+++ b/src/caveats.ts
@@ -45,7 +45,7 @@ export const filterResponse: ICaveatFunctionGenerator = function filterResponse 
 /*
  * Limits array results to a specific integer length.
  */
-export const limitResponse: ICaveatFunctionGenerator = function limitResponse (serialized: IOcapLdCaveat) {
+export const limitResponseLength: ICaveatFunctionGenerator = function limitResponseLength (serialized: IOcapLdCaveat) {
   const { value } = serialized;
   return (_req, res, next, _end): void => {
 

--- a/test/caveats.js
+++ b/test/caveats.js
@@ -242,6 +242,124 @@ test('filterResponse caveat passes through subset portion of response', async (t
   t.end();
 });
 
+test('limitResponse caveat returns all results if less than value.', async (t) => {
+  const domain = { origin: 'www.metamask.io' };
+  const items = [
+    '0x44ed36e289cd9e8de4d822ad373ae42aac890a68',
+    '0x404d0886ad4933630160c169fffa1084d15b7beb',
+    '0x30476e1d96ae0ebaae94558afa146b0023df2d07',
+  ];
+
+  const ctrl = new CapabilitiesController({
+    restrictedMethods: {
+      'readAccounts': {
+        method: (_req, res, _next, end) => {
+          res.result = items;
+          end();
+        },
+      },
+    },
+
+    requestUserApproval: async (permissionsRequest) => {
+      const perms = permissionsRequest.permissions;
+      perms.readAccounts.caveats = [
+        { type: 'limitResponse', value: 10 },
+      ];
+      return perms;
+    },
+  },
+  {
+    domains: {},
+  });
+
+  try {
+    let req = {
+      method: 'requestPermissions',
+      params: [
+        {
+          'readAccounts': {},
+        },
+      ],
+    };
+
+    await sendRpcMethodWithResponse(ctrl, domain, req);
+
+    // Now let's call that restricted method:
+    req = {
+      method: 'readAccounts',
+      params: [
+        'notAllowed',
+        { definitely: 'restricted' },
+      ],
+    };
+
+    const result = await sendRpcMethodWithResponse(ctrl, domain, req);
+    t.equal(result.length, 3, 'All(3) items');
+    t.equal(result[0], items[0], 'Returns in original order');
+
+  } catch (err) {
+    t.notOk(err, 'should not throw');
+  }
+  t.end();
+});
+
+test('limitResponse caveat returns only the specified number of values when original exceeds that number', async (t) => {
+  const domain = { origin: 'www.metamask.io' };
+
+  const ctrl = new CapabilitiesController({
+    restrictedMethods: {
+      'write': {
+        method: (_req, res, _next, end) => {
+          res.result = [1, 2, 3, 4, 5];
+          end();
+        },
+      },
+    },
+
+    // User approves on condition of first arg being 'foo',
+    // and second arg having the 'bar': 'baz' value.
+    requestUserApproval: async (permissionsRequest) => {
+      const perms = permissionsRequest.permissions;
+      perms.write.caveats = [
+        { type: 'limitResponse', value: 3 },
+      ];
+      return perms;
+    },
+  },
+  {
+    domains: {},
+  });
+
+  try {
+    let req = {
+      method: 'requestPermissions',
+      params: [
+        {
+          'write': {},
+        },
+      ],
+    };
+
+    await sendRpcMethodWithResponse(ctrl, domain, req);
+
+    // Now let's call that restricted method:
+    req = {
+      method: 'write',
+      params: [],
+    };
+
+    const result = await sendRpcMethodWithResponse(ctrl, domain, req);
+
+    t.ok(result, 'should succeed');
+    t.deepEqual(result, [1, 2, 3], 'returned the correct subset');
+
+  } catch (err) {
+    t.notOk(err, 'should not throw');
+  }
+  t.end();
+});
+
+
 test('forceParams caveat overwrites', async (t) => {
   const domain = { origin: 'www.metamask.io' };
 

--- a/test/caveats.js
+++ b/test/caveats.js
@@ -242,7 +242,7 @@ test('filterResponse caveat passes through subset portion of response', async (t
   t.end();
 });
 
-test('limitResponse caveat returns all results if less than value.', async (t) => {
+test('limitResponseLength caveat returns all results if less than value.', async (t) => {
   const domain = { origin: 'www.metamask.io' };
   const items = [
     '0x44ed36e289cd9e8de4d822ad373ae42aac890a68',
@@ -263,7 +263,7 @@ test('limitResponse caveat returns all results if less than value.', async (t) =
     requestUserApproval: async (permissionsRequest) => {
       const perms = permissionsRequest.permissions;
       perms.readAccounts.caveats = [
-        { type: 'limitResponse', value: 10 },
+        { type: 'limitResponseLength', value: 10 },
       ];
       return perms;
     },
@@ -303,7 +303,7 @@ test('limitResponse caveat returns all results if less than value.', async (t) =
   t.end();
 });
 
-test('limitResponse caveat returns only the specified number of values when original exceeds that number', async (t) => {
+test('limitResponseLength caveat returns only the specified number of values when original exceeds that number', async (t) => {
   const domain = { origin: 'www.metamask.io' };
 
   const ctrl = new CapabilitiesController({
@@ -321,7 +321,7 @@ test('limitResponse caveat returns only the specified number of values when orig
     requestUserApproval: async (permissionsRequest) => {
       const perms = permissionsRequest.permissions;
       perms.write.caveats = [
-        { type: 'limitResponse', value: 3 },
+        { type: 'limitResponseLength', value: 3 },
       ];
       return perms;
     },


### PR DESCRIPTION
Adds a limitResponse caveat that slices an array response to the specified length.