### PR TITLE
Lint everything, update eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,27 @@
 module.exports = {
-  root: true,
   extends: [
     '@metamask/eslint-config',
     '@metamask/eslint-config/config/nodejs',
     '@metamask/eslint-config/config/typescript',
+  ],
+  rules: {
+    '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
+    '@typescript-eslint/interface-name-prefix': 'off',
+  },
+  ignorePatterns: [
+    '!.eslintrc.js',
+    'node_modules/',
+    'dist/',
+  ],
+  overrides: [
+    {
+      files: ['*.js'],
+      rules: {
+        '@typescript-eslint/explicit-function-return-type': 'off',
+        '@typescript-eslint/no-var-requires': 'off',
+        '@typescript-eslint/no-empty-function': 'off',
+        '@typescript-eslint/camelcase': 'off',
+      },
+    },
   ],
 };

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/uuid": "^3.4.4",
     "@typescript-eslint/eslint-plugin": "^2.17.0",
     "@typescript-eslint/parser": "^2.17.0",
-    "eslint": "6.8.0",
+    "eslint": "^6.8.0",
     "nyc": "^15.0.0",
     "tape": "^4.9.2",
     "typescript": "^3.7.5"

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "build:typescript": "rm -rf dist && tsc",
     "build:types": "./scripts/copyDistTypes.sh",
     "build:watch": "yarn build && tsc -w",
-    "lint": "eslint --ext .ts index.ts",
-    "lint:fix": "eslint --ext .ts --fix index.ts",
+    "lint": "eslint --ext .ts,.js .",
+    "lint:fix": "eslint --ext .ts,.js --fix .",
     "prepublishOnly": "yarn build",
     "test": "yarn build:typescript && node test",
     "test:coverage": "nyc node test"
@@ -29,7 +29,7 @@
     "@types/uuid": "^3.4.4",
     "@typescript-eslint/eslint-plugin": "^2.17.0",
     "@typescript-eslint/parser": "^2.17.0",
-    "eslint": "^6.2.1",
+    "eslint": "6.8.0",
     "nyc": "^15.0.0",
     "tape": "^4.9.2",
     "typescript": "^3.7.5"

--- a/src/@types/gaba.d.ts
+++ b/src/@types/gaba.d.ts
@@ -1,60 +1,180 @@
 /**
+ * Controller class that provides configuration, state management, and subscriptions
+ */
+export declare class BaseController<C extends BaseConfig, S extends BaseState> {
+
+  /**
+   * Map of all sibling child controllers keyed by name if this
+   * controller is composed using a ComposableController, allowing
+   * any API on any sibling controller to be accessed
+   */
+  context: ChildControllerContext;
+
+  /**
+   * Default options used to configure this controller
+   */
+  defaultConfig: C;
+
+  /**
+   * Default state set on this controller
+   */
+  defaultState: S;
+
+  /**
+   * Determines if listeners are notified of state changes
+   */
+  disabled: boolean;
+
+  /**
+   * Name of this controller used during composition
+   */
+  name: string;
+
+  /**
+   * List of required sibling controllers this controller needs to function
+   */
+  requiredControllers: string[];
+  private initialConfig;
+  private initialState;
+  private internalConfig;
+  private internalState;
+  private internalListeners;
+
+  /**
+   * Creates a BaseController instance. Both initial state and initial
+   * configuration options are merged with defaults upon initialization.
+   *
+   * @param config - Initial options used to configure this controller
+   * @param state - Initial state to set on this controller
+   */
+  constructor(config?: Partial<C>, state?: Partial<S>);
+
+  /**
+   * Enables the controller. This sets each config option as a member
+   * variable on this instance and triggers any defined setters. This
+   * also sets initial state and triggers any listeners.
+   *
+   * @returns - This controller instance
+   */
+  protected initialize(): this;
+
+  /**
+   * Retrieves current controller configuration options
+   *
+   * @returns - Current configuration
+   */
+  readonly config: C;
+
+  /**
+   * Retrieves current controller state
+   *
+   * @returns - Current state
+   */
+  readonly state: S;
+
+  /**
+   * Updates controller configuration
+   *
+   * @param config - New configuration options
+   * @param overwrite - Overwrite config instead of merging
+   * @param fullUpdate - Boolean that defines if the update is partial or not
+   */
+  configure(config: Partial<C>, overwrite?: boolean, fullUpdate?: boolean): void;
+
+  /**
+   * Notifies all subscribed listeners of current state
+   */
+  notify(): void;
+
+  /**
+   * Extension point called if and when this controller is composed
+   * with other controllers using a ComposableController
+   */
+  onComposed(): void;
+
+  /**
+   * Adds new listener to be notified of state changes
+   *
+   * @param listener - Callback triggered when state changes
+   */
+  subscribe(listener: Listener<S>): void;
+
+  /**
+   * Removes existing listener from receiving state changes
+   *
+   * @param listener - Callback to remove
+   * @returns - True if a listener is found and unsubscribed
+   */
+  unsubscribe(listener: Listener<S>): boolean;
+
+  /**
+   * Updates controller state
+   *
+   * @param state - New state
+   * @param overwrite - Overwrite state instead of merging
+   */
+  update(state: Partial<S>, overwrite?: boolean): void;
+}
+
+/**
  * Child controller instances keyed by controller name
  */
 export interface ChildControllerContext {
-    [key: string]: BaseController<any, any>;
+  [key: string]: BaseController<any, any>;
 }
+
 /**
  * List of child controller instances
  */
-export declare type ControllerList = Array<BaseController<any, any>>;
+export declare type ControllerList = BaseController<any, any>[];
+
 /**
  * Controller that can be used to compose mutiple controllers together
  */
 export declare class ComposableController extends BaseController<any, any> {
-    private cachedState;
-    private internalControllers;
-    /**
+  private cachedState;
+  private internalControllers;
+  /**
      * Map of stores to compose together
      */
-    context: ChildControllerContext;
-    /**
+  context: ChildControllerContext;
+  /**
      * Name of this controller used during composition
      */
-    name: string;
-    /**
+  name: string;
+  /**
      * Creates a ComposableController instance
      *
      * @param controllers - Map of names to controller instances
      * @param initialState - Initial state keyed by child controller name
      */
-    constructor(controllers?: ControllerList, initialState?: any);
-    /**
+  constructor(controllers?: ControllerList, initialState?: any);
+  /**
      * Get current list of child composed store instances
      *
      * @returns - List of names to controller instances
      */
-    /**
+  /**
     * Set new list of controller instances
     *
     * @param controllers - List of names to controller instsances
     */
-    controllers: ControllerList;
-    /**
+  controllers: ControllerList;
+  /**
      * Flat state representation, one that isn't keyed
      * of controller name. Instead, all child controller state is merged
      * together into a single, flat object.
      *
      * @returns - Merged state representation of all child controllers
      */
-    readonly flatState: {};
+  readonly flatState: {};
 }
-
 
 /**
  * State change callbacks
  */
 export declare type Listener<T> = (state: T) => void;
+
 /**
  * @type BaseConfig
  *
@@ -63,8 +183,9 @@ export declare type Listener<T> = (state: T) => void;
  * @property disabled - Determines if this controller is enabled
  */
 export interface BaseConfig {
-    disabled?: boolean;
+  disabled?: boolean;
 }
+
 /**
  * @type BaseState
  *
@@ -73,108 +194,7 @@ export interface BaseConfig {
  * @property name - Unique name for this controller
  */
 export interface BaseState {
-    name?: string;
-}
-/**
- * Controller class that provides configuration, state management, and subscriptions
- */
-export declare class BaseController<C extends BaseConfig, S extends BaseState> {
-    /**
-     * Map of all sibling child controllers keyed by name if this
-     * controller is composed using a ComposableController, allowing
-     * any API on any sibling controller to be accessed
-     */
-    context: ChildControllerContext;
-    /**
-     * Default options used to configure this controller
-     */
-    defaultConfig: C;
-    /**
-     * Default state set on this controller
-     */
-    defaultState: S;
-    /**
-     * Determines if listeners are notified of state changes
-     */
-    disabled: boolean;
-    /**
-     * Name of this controller used during composition
-     */
-    name: string;
-    /**
-     * List of required sibling controllers this controller needs to function
-     */
-    requiredControllers: string[];
-    private initialConfig;
-    private initialState;
-    private internalConfig;
-    private internalState;
-    private internalListeners;
-    /**
-     * Creates a BaseController instance. Both initial state and initial
-     * configuration options are merged with defaults upon initialization.
-     *
-     * @param config - Initial options used to configure this controller
-     * @param state - Initial state to set on this controller
-     */
-    constructor(config?: Partial<C>, state?: Partial<S>);
-    /**
-     * Enables the controller. This sets each config option as a member
-     * variable on this instance and triggers any defined setters. This
-     * also sets initial state and triggers any listeners.
-     *
-     * @returns - This controller instance
-     */
-    protected initialize(): this;
-    /**
-     * Retrieves current controller configuration options
-     *
-     * @returns - Current configuration
-     */
-    readonly config: C;
-    /**
-     * Retrieves current controller state
-     *
-     * @returns - Current state
-     */
-    readonly state: S;
-    /**
-     * Updates controller configuration
-     *
-     * @param config - New configuration options
-     * @param overwrite - Overwrite config instead of merging
-     * @param fullUpdate - Boolean that defines if the update is partial or not
-     */
-    configure(config: Partial<C>, overwrite?: boolean, fullUpdate?: boolean): void;
-    /**
-     * Notifies all subscribed listeners of current state
-     */
-    notify(): void;
-    /**
-     * Extension point called if and when this controller is composed
-     * with other controllers using a ComposableController
-     */
-    onComposed(): void;
-    /**
-     * Adds new listener to be notified of state changes
-     *
-     * @param listener - Callback triggered when state changes
-     */
-    subscribe(listener: Listener<S>): void;
-    /**
-     * Removes existing listener from receiving state changes
-     *
-     * @param listener - Callback to remove
-     * @returns - True if a listener is found and unsubscribed
-     */
-    unsubscribe(listener: Listener<S>): boolean;
-    /**
-     * Updates controller state
-     *
-     * @param state - New state
-     * @param overwrite - Overwrite state instead of merging
-     */
-    update(state: Partial<S>, overwrite?: boolean): void;
+  name?: string;
 }
 
 export default BaseController;

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -1,24 +1,20 @@
 import {
-  JsonRpcRequest,
-  JsonRpcResponse,
   JsonRpcEngine,
-} from 'json-rpc-engine';
-import {
   JsonRpcMiddleware,
   JsonRpcEngineEndCallback,
-  JsonRpcEngineNextCallback
+  JsonRpcEngineNextCallback,
+  JsonRpcRequest,
+  JsonRpcResponse,
 } from 'json-rpc-engine';
 import { IOcapLdCapability } from './ocap-ld';
 
-export interface AuthenticatedJsonRpcMiddleware {
-  (
-    domain: IOriginMetadata,
-    req: JsonRpcRequest<any>,
-    res: JsonRpcResponse<any>,
-    next: JsonRpcEngineNextCallback,
-    end: JsonRpcEngineEndCallback,
-  ): void;
-}
+export type AuthenticatedJsonRpcMiddleware = (
+  domain: IOriginMetadata,
+  req: JsonRpcRequest<any>,
+  res: JsonRpcResponse<any>,
+  next: JsonRpcEngineNextCallback,
+  end: JsonRpcEngineEndCallback,
+) => void;
 
 /**
  * Used for prompting the user about a proposed new permission.
@@ -38,12 +34,14 @@ export interface IOriginMetadata {
 /**
  * The format submitted by a domain to request an expanded set of permissions.
  * Assumes knowledge of the requesting domain's context.
- * 
+ *
  * Uses a map to emphasize that there will ultimately be one set of permissions per domain per method.
- * 
+ *
  * Is a key-value store of method names, to IMethodRequest objects, which have a caveats array.
  */
-export interface IRequestedPermissions { [methodName: string]: IMethodRequest }
+export interface IRequestedPermissions {
+  [methodName: string]: IMethodRequest;
+}
 
 /**
  * Object used to request a given permission within reasonable terms.
@@ -51,17 +49,13 @@ export interface IRequestedPermissions { [methodName: string]: IMethodRequest }
  */
 type IMethodRequest = Partial<IOcapLdCapability>;
 
-export interface UserApprovalPrompt {
-  (permissionsRequest: IPermissionsRequest): Promise<IRequestedPermissions>;
-}
+export type UserApprovalPrompt = (permissionsRequest: IPermissionsRequest) => Promise<IRequestedPermissions>;
 
 export interface RpcCapDomainEntry {
   permissions: IOcapLdCapability[];
 }
 
 type IOriginString = string;
-
-export interface ISemanticCaveatTypeConfig {}
 
 export interface CapabilitiesConfig {
   requestUserApproval: UserApprovalPrompt;
@@ -70,10 +64,11 @@ export interface CapabilitiesConfig {
   methodPrefix?: string;
   restrictedMethods?: RestrictedMethodMap;
   safeMethods?: string[];
-  semanticCaveatTypes?: { [name: string]: ISemanticCaveatTypeConfig };
 }
 
-type RpcCapDomainRegistry = { [domain:string]: RpcCapDomainEntry };
+interface RpcCapDomainRegistry {
+  [domain: string]: RpcCapDomainEntry;
+}
 
 export interface CapabilitiesState {
   domains: RpcCapDomainRegistry;
@@ -82,7 +77,7 @@ export interface CapabilitiesState {
 export interface RestrictedMethodEntry {
   description: string;
   method: PermittedJsonRpcMiddleware;
-} 
+}
 
 export interface PermittedJsonRpcMiddleware extends JsonRpcMiddleware {
   (req: JsonRpcRequest<any>, res: JsonRpcResponse<any>, next: JsonRpcEngineNextCallback, end: JsonRpcEngineEndCallback, engine?: JsonRpcEngine): void;
@@ -96,13 +91,24 @@ export interface RpcCapInterface {
   getPermissionsForDomain: (domain: string) => IOcapLdCapability[];
   getPermission: (domain: string, method: string) => IOcapLdCapability | undefined;
   getPermissionsRequests: () => IPermissionsRequest[];
-  grantNewPermissions (domain: string, approved: IRequestedPermissions, res: JsonRpcResponse<any>, end: JsonRpcEngineEndCallback, granter?: string): void;
+  grantNewPermissions (
+    domain: string,
+    approved: IRequestedPermissions,
+    res: JsonRpcResponse<any>,
+    end: JsonRpcEngineEndCallback,
+    granter?: string
+  ): void;
   getDomains: () => RpcCapDomainRegistry;
   setDomains: (domains: RpcCapDomainRegistry) => void;
   getDomainSettings: (domain: string) => RpcCapDomainEntry | undefined;
   getOrCreateDomainSettings: (domain: string) => RpcCapDomainEntry;
   setDomain: (domain: string, settings: RpcCapDomainEntry) => void;
-  addPermissionsFor: (domainName: string, newPermissions: { [methodName: string]: IOcapLdCapability }) => void;
+  addPermissionsFor: (
+    domainName: string,
+    newPermissions: {
+      [methodName: string]: IOcapLdCapability;
+    }
+  ) => void;
   removePermissionsFor: (domain: string, permissionsToRemove: IOcapLdCapability[]) => void;
   createBoundMiddleware: (domain: string) => PermittedJsonRpcMiddleware;
   createPermissionedEngine: (domain: string) => JsonRpcEngine;

--- a/src/@types/is-subset.d.ts
+++ b/src/@types/is-subset.d.ts
@@ -1,2 +1,2 @@
-export type isSubset = (superset: Object, subset: Object) => boolean;
-export type intersectObjects = (arg1?: Object, arg2?: Object) => Object;
+export type isSubset = (superset: Record<string, any>, subset: Record<string, any>) => boolean;
+export type intersectObjects = (arg1?: Record<string, any>, arg2?: Record<string, any>) => Record<string, any>;

--- a/src/@types/ocap-ld.d.ts
+++ b/src/@types/ocap-ld.d.ts
@@ -1,16 +1,16 @@
 /**
  * The schema used to serialize an assigned permission for a method to a domain.
- * 
+ *
  * Roughly implements the ocap-ld schema:
  * https://w3c-ccg.github.io/ocap-ld/
- * 
+ *
  * Does not currently include signatures or nested delegated capabilities.
  * Both of these would be good extensions later on, and some prior work has been done
  * in that direction at digitalbazaar:
  * https://github.com/digitalbazaar/ocapld.js/
  */
 interface IOcapLdCapability {
-  "@context": string[];
+  '@context': string[];
   // A GUID representing this method.
   id: string;
   // A pointer to the resource to invoke, like an API url,
@@ -25,22 +25,22 @@ interface IOcapLdCapability {
   proof?: IOcapLdProof;
 }
 
-export type IOcapLdCaveat = {
+export interface IOcapLdCaveat {
   // A type identifying the type of caveat.
-  type: string,
+  type: string;
   // Any additional data required to enforce the caveat type.
   value?: any;
   // Unique identifier for use in the client layer
   name?: string;
 }
 
-export type IOcapLdProof = {
+export interface IOcapLdProof {
   type: string;
-  proofPurpose: "capabilityDelegation" | "capabilityInvocation";
+  proofPurpose: 'capabilityDelegation' | 'capabilityInvocation';
   // A date string
   created: string;
   // A link to the creator.
   creator: string;
   // Dependent on the type, an arbitrary signature value.
   signatureValue?: string;
-};
+}

--- a/src/caveats.ts
+++ b/src/caveats.ts
@@ -1,19 +1,19 @@
 import { JsonRpcMiddleware } from 'json-rpc-engine';
 import { isSubset } from './@types/is-subset';
-import { IOcapLdCaveat } from './@types/ocap-ld'
+import { IOcapLdCaveat } from './@types/ocap-ld';
 import { unauthorized } from './errors';
-const isSubset = require('is-subset');
+const isSubset = require('is-subset'); // eslint-disable-line
 
 export type ICaveatFunction = JsonRpcMiddleware;
 
-export type ICaveatFunctionGenerator = (caveat:IOcapLdCaveat) => ICaveatFunction;
+export type ICaveatFunctionGenerator = (caveat: IOcapLdCaveat) => ICaveatFunction;
 
 /*
  * Require that the request params match those specified by the caveat value.
  */
-export const requireParams: ICaveatFunctionGenerator = function requireParams(serialized: IOcapLdCaveat) {
+export const requireParams: ICaveatFunctionGenerator = function requireParams (serialized: IOcapLdCaveat) {
   const { value } = serialized;
-  return (req, res, next, end) => {
+  return (req, res, next, end): void => {
     const permitted = isSubset(req.params, value);
 
     if (!permitted) {
@@ -22,34 +22,34 @@ export const requireParams: ICaveatFunctionGenerator = function requireParams(se
     }
 
     next();
-  }
-}
+  };
+};
 
 /*
  * Filters array results shallowly.
  */
-export const filterResponse: ICaveatFunctionGenerator = function filterResponse(serialized: IOcapLdCaveat) {
+export const filterResponse: ICaveatFunctionGenerator = function filterResponse (serialized: IOcapLdCaveat) {
   const { value } = serialized;
-  return (_req, res, next, _end) => {
+  return (_req, res, next, _end): void => {
 
     next((done) => {
       if (Array.isArray(res.result)) {
         res.result = res.result.filter((item) => {
           return value.includes(item);
-        })
+        });
       }
       done();
     });
-  }
-}
+  };
+};
 
 /*
  * Forces the method to be called with given params.
  */
-export const forceParams: ICaveatFunctionGenerator = function forceParams(serialized: IOcapLdCaveat) {
+export const forceParams: ICaveatFunctionGenerator = function forceParams (serialized: IOcapLdCaveat) {
   const { value } = serialized;
-  return (req, _, next) => {
-      req.params = [ ...value ]
-      next();
+  return (req, _, next): void => {
+    req.params = [ ...value ];
+    next();
   };
-}
+};

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -5,31 +5,31 @@ import { IEthErrors, IEthereumRpcError } from 'eth-json-rpc-errors/@types';
 const ethErrors: IEthErrors = require('eth-json-rpc-errors').ethErrors;
 
 interface ErrorArg {
-  message?: string,
-  data?: JsonRpcRequest<any> | any
+  message?: string;
+  data?: JsonRpcRequest<any> | any;
 }
 
 interface MethodNotFoundArg extends ErrorArg {
-  methodName?: string,
+  methodName?: string;
 }
 
 function unauthorized (arg?: ErrorArg): IEthereumRpcError<JsonRpcRequest<any>> {
   return ethErrors.provider.unauthorized({
-    message: (arg && arg.message) || 'Unauthorized to perform action. Try requesting permission first using the `requestPermissions` method. More info available at https://github.com/MetaMask/rpc-cap',
-    data: (arg && arg.data) || undefined
+    message: arg?.message || 'Unauthorized to perform action. Try requesting permission first using the `requestPermissions` method. More info available at https://github.com/MetaMask/rpc-cap',
+    data: arg?.data || undefined,
   });
 }
 
-const invalidReq = ethErrors.rpc.invalidRequest
+const invalidReq = ethErrors.rpc.invalidRequest;
 
-const internalError = ethErrors.rpc.internal
+const internalError = ethErrors.rpc.internal;
 
 function methodNotFound (opts: MethodNotFoundArg): IEthereumRpcError<JsonRpcRequest<any>> {
-  const message = (
+  const message =
     opts.methodName
       ? `The method '${opts.methodName}' does not exist / is not available.`
-      : null
-  )
+      : null;
+
   return ethErrors.rpc.methodNotFound({ data: opts.data, message });
 }
 

--- a/test/caveats.js
+++ b/test/caveats.js
@@ -1,10 +1,10 @@
-/// <reference path="../index.ts" />
+// / <reference path="../index.ts" />
 
 const test = require('tape');
-const CapabilitiesController = require('../dist').CapabilitiesController
+const CapabilitiesController = require('../dist').CapabilitiesController;
 const sendRpcMethodWithResponse = require('./lib/utils').sendRpcMethodWithResponse;
 
-const UNAUTHORIZED_CODE = require('eth-json-rpc-errors').ERROR_CODES.provider.unauthorized
+const UNAUTHORIZED_CODE = require('eth-json-rpc-errors').ERROR_CODES.provider.unauthorized;
 
 test('requireParams caveat throws if caveat value is not a subset of params.', async (t) => {
   const domain = { origin: 'www.metamask.io' };
@@ -16,8 +16,8 @@ test('requireParams caveat throws if caveat value is not a subset of params.', a
           const params = req.params;
           res.result = params;
           end();
-        }
-      }
+        },
+      },
     },
 
     // User approves on condition of first arg being 'foo',
@@ -26,13 +26,13 @@ test('requireParams caveat throws if caveat value is not a subset of params.', a
       const perms = permissionsRequest.permissions;
       perms.write.caveats = [
         { type: 'requireParams', value: ['foo', { bar: 'baz' }] },
-      ]
+      ];
       return perms;
     },
   },
   {
-    domains: {}
-  })
+    domains: {},
+  });
 
   try {
     let req = {
@@ -40,8 +40,8 @@ test('requireParams caveat throws if caveat value is not a subset of params.', a
       params: [
         {
           'write': {},
-        }
-      ]
+        },
+      ],
     };
 
     await sendRpcMethodWithResponse(ctrl, domain, req);
@@ -52,34 +52,34 @@ test('requireParams caveat throws if caveat value is not a subset of params.', a
       params: [
         'notAllowed',
         { definitely: 'restricted' },
-      ]
-    }
+      ],
+    };
 
     await sendRpcMethodWithResponse(ctrl, domain, req);
-    t.notOk(true, 'should have thrown')
+    t.notOk(true, 'should have thrown');
 
   } catch (err) {
     t.ok(err, 'should throw');
     t.equal(err.code, UNAUTHORIZED_CODE, 'Auth error code.');
   }
   t.end();
-})
+});
 
 test('requireParams caveat passes through if caveat value is a subset of params.', async (t) => {
   const domain = { origin: 'www.metamask.io' };
   const params = [
     'foo',
     { bar: 'baz', also: 'bonusParams!' },
-  ]
+  ];
 
   const ctrl = new CapabilitiesController({
     restrictedMethods: {
       'write': {
-        method: (req, res, next, end) => {
+        method: (_req, res, _next, end) => {
           res.result = 'Success';
           end();
-        }
-      }
+        },
+      },
     },
 
     // User approves on condition of first arg being 'foo',
@@ -88,13 +88,13 @@ test('requireParams caveat passes through if caveat value is a subset of params.
       const perms = permissionsRequest.permissions;
       perms.write.caveats = [
         { type: 'requireParams', value: ['foo', { bar: 'baz' }] },
-      ]
+      ];
       return perms;
     },
   },
   {
-    domains: {}
-  })
+    domains: {},
+  });
 
   try {
     let req = {
@@ -102,8 +102,8 @@ test('requireParams caveat passes through if caveat value is a subset of params.
       params: [
         {
           'write': {},
-        }
-      ]
+        },
+      ],
     };
 
     await sendRpcMethodWithResponse(ctrl, domain, req);
@@ -112,7 +112,7 @@ test('requireParams caveat passes through if caveat value is a subset of params.
     req = {
       method: 'write',
       params,
-    }
+    };
 
     const result = await sendRpcMethodWithResponse(ctrl, domain, req);
 
@@ -123,7 +123,7 @@ test('requireParams caveat passes through if caveat value is a subset of params.
     t.notOk(err, 'should not throw');
   }
   t.end();
-})
+});
 
 test('filterResponse caveat returns empty if params are not a subset.', async (t) => {
   const domain = { origin: 'www.metamask.io' };
@@ -131,29 +131,29 @@ test('filterResponse caveat returns empty if params are not a subset.', async (t
     '0x44ed36e289cd9e8de4d822ad373ae42aac890a68',
     '0x404d0886ad4933630160c169fffa1084d15b7beb',
     '0x30476e1d96ae0ebaae94558afa146b0023df2d07',
-  ]
+  ];
 
   const ctrl = new CapabilitiesController({
     restrictedMethods: {
       'readAccounts': {
-        method: (req, res, next, end) => {
+        method: (_req, res, _next, end) => {
           res.result = items;
           end();
-        }
-      }
+        },
+      },
     },
 
     requestUserApproval: async (permissionsRequest) => {
       const perms = permissionsRequest.permissions;
       perms.readAccounts.caveats = [
         { type: 'filterResponse', value: [items[1], '123'] },
-      ]
+      ];
       return perms;
     },
   },
   {
-    domains: {}
-  })
+    domains: {},
+  });
 
   try {
     let req = {
@@ -161,8 +161,8 @@ test('filterResponse caveat returns empty if params are not a subset.', async (t
       params: [
         {
           'readAccounts': {},
-        }
-      ]
+        },
+      ],
     };
 
     await sendRpcMethodWithResponse(ctrl, domain, req);
@@ -173,8 +173,8 @@ test('filterResponse caveat returns empty if params are not a subset.', async (t
       params: [
         'notAllowed',
         { definitely: 'restricted' },
-      ]
-    }
+      ],
+    };
 
     const result = await sendRpcMethodWithResponse(ctrl, domain, req);
     t.equal(result.length, 1, 'A single item');
@@ -184,7 +184,7 @@ test('filterResponse caveat returns empty if params are not a subset.', async (t
     t.notOk(err, 'should not throw');
   }
   t.end();
-})
+});
 
 test('filterResponse caveat passes through subset portion of response', async (t) => {
   const domain = { origin: 'www.metamask.io' };
@@ -192,11 +192,11 @@ test('filterResponse caveat passes through subset portion of response', async (t
   const ctrl = new CapabilitiesController({
     restrictedMethods: {
       'write': {
-        method: (req, res, next, end) => {
-          res.result = [1,2,3,4,5];
+        method: (_req, res, _next, end) => {
+          res.result = [1, 2, 3, 4, 5];
           end();
-        }
-      }
+        },
+      },
     },
 
     // User approves on condition of first arg being 'foo',
@@ -204,14 +204,14 @@ test('filterResponse caveat passes through subset portion of response', async (t
     requestUserApproval: async (permissionsRequest) => {
       const perms = permissionsRequest.permissions;
       perms.write.caveats = [
-        { type: 'filterResponse', value: [0,1,2,3]},
-      ]
+        { type: 'filterResponse', value: [0, 1, 2, 3] },
+      ];
       return perms;
     },
   },
   {
-    domains: {}
-  })
+    domains: {},
+  });
 
   try {
     let req = {
@@ -219,8 +219,8 @@ test('filterResponse caveat passes through subset portion of response', async (t
       params: [
         {
           'write': {},
-        }
-      ]
+        },
+      ],
     };
 
     await sendRpcMethodWithResponse(ctrl, domain, req);
@@ -229,18 +229,18 @@ test('filterResponse caveat passes through subset portion of response', async (t
     req = {
       method: 'write',
       params: [],
-    }
+    };
 
     const result = await sendRpcMethodWithResponse(ctrl, domain, req);
 
     t.ok(result, 'should succeed');
-    t.deepEqual(result, [1,2,3], 'returned the correct subset');
+    t.deepEqual(result, [1, 2, 3], 'returned the correct subset');
 
   } catch (err) {
     t.notOk(err, 'should not throw');
   }
   t.end();
-})
+});
 
 test('forceParams caveat overwrites', async (t) => {
   const domain = { origin: 'www.metamask.io' };
@@ -248,11 +248,11 @@ test('forceParams caveat overwrites', async (t) => {
   const ctrl = new CapabilitiesController({
     restrictedMethods: {
       'testMethod': {
-        method: (req, res, next, end) => {
+        method: (req, res, _next, end) => {
           res.result = req.params;
           end();
-        }
-      }
+        },
+      },
     },
 
     // User approves on condition of first arg being 'foo',
@@ -262,8 +262,8 @@ test('forceParams caveat overwrites', async (t) => {
     },
   },
   {
-    domains: {}
-  })
+    domains: {},
+  });
 
   try {
     let req = {
@@ -272,11 +272,11 @@ test('forceParams caveat overwrites', async (t) => {
         {
           'testMethod': {
             caveats: [
-              { type: 'forceParams', value: [0,1,2,3] },
-            ]
+              { type: 'forceParams', value: [0, 1, 2, 3] },
+            ],
           },
-        }
-      ]
+        },
+      ],
     };
 
     await sendRpcMethodWithResponse(ctrl, domain, req);
@@ -285,18 +285,18 @@ test('forceParams caveat overwrites', async (t) => {
     req = {
       method: 'testMethod',
       params: [],
-    }
+    };
 
     const result = await sendRpcMethodWithResponse(ctrl, domain, req);
 
     t.ok(result, 'should succeed');
-    t.deepEqual(result, [0,1,2,3], 'returned the correct subset');
+    t.deepEqual(result, [0, 1, 2, 3], 'returned the correct subset');
 
   } catch (err) {
     t.notOk(err, 'should not throw');
   }
   t.end();
-})
+});
 
 test('named caveats', async (t) => {
   const domain = { origin: 'www.metamask.io' };
@@ -307,8 +307,8 @@ test('named caveats', async (t) => {
         method: (req, res, _next, end) => {
           res.result = req.params;
           end();
-        }
-      }
+        },
+      },
     },
 
     // All permissions automatically approved
@@ -317,11 +317,11 @@ test('named caveats', async (t) => {
     },
   },
   {
-    domains: {}
-  })
+    domains: {},
+  });
 
   try {
-    let req = {
+    const req = {
       method: 'requestPermissions',
       params: [
         {
@@ -329,20 +329,20 @@ test('named caveats', async (t) => {
             caveats: [
               {
                 type: 'forceParams',
-                value: [0,1,2,3],
-                name: 'a'
+                value: [0, 1, 2, 3],
+                name: 'a',
               },
-            ]
+            ],
           },
-        }
-      ]
-    }
+        },
+      ],
+    };
 
     await sendRpcMethodWithResponse(ctrl, domain, req);
 
     test('can add caveats with different names', async (t) => {
       try {
-        let req = {
+        const req = {
           method: 'requestPermissions',
           params: [
             {
@@ -350,32 +350,32 @@ test('named caveats', async (t) => {
                 caveats: [
                   {
                     type: 'forceParams',
-                    value: [0,1,2,3],
-                    name: 'a'
+                    value: [0, 1, 2, 3],
+                    name: 'a',
                   },
                   {
                     type: 'forceParams',
-                    value: [0,1,2,3],
-                    name: 'b'
+                    value: [0, 1, 2, 3],
+                    name: 'b',
                   },
-                ]
+                ],
               },
-            }
-          ]
-        }
+            },
+          ],
+        };
 
-        let res = await sendRpcMethodWithResponse(ctrl, domain, req);
+        const res = await sendRpcMethodWithResponse(ctrl, domain, req);
         t.ok(res, 'received response');
 
       } catch (err) {
         t.notOk(err, 'should not throw');
       }
       t.end();
-    })
+    });
 
     test('fails when adding multiple caveats with the same name', async (t) => {
       try {
-        let req = {
+        const req = {
           method: 'requestPermissions',
           params: [
             {
@@ -383,22 +383,22 @@ test('named caveats', async (t) => {
                 caveats: [
                   {
                     type: 'forceParams',
-                    value: [0,1,2,3],
-                    name: 'a'
+                    value: [0, 1, 2, 3],
+                    name: 'a',
                   },
                   {
                     type: 'forceParams',
-                    value: [0,1,2,3],
-                    name: 'a'
+                    value: [0, 1, 2, 3],
+                    name: 'a',
                   },
-                ]
+                ],
               },
-            }
-          ]
-        }
+            },
+          ],
+        };
 
         await sendRpcMethodWithResponse(ctrl, domain, req);
-        t.notOk(true, 'should have thrown')
+        t.notOk(true, 'should have thrown');
 
       } catch (err) {
         t.ok(err.message.indexOf('Invalid caveats.') !== -1, 'throws expected error');
@@ -409,7 +409,7 @@ test('named caveats', async (t) => {
     t.notOk(err, 'should not throw');
   }
   t.end();
-})
+});
 
 test('updateCaveatFor', async (t) => {
 
@@ -417,16 +417,15 @@ test('updateCaveatFor', async (t) => {
 
   const cav1 = {
     type: 'forceParams',
-    value: [0,1,2,3],
-    name: 'a'
-  }
+    value: [0, 1, 2, 3],
+    name: 'a',
+  };
 
   const cav2 = {
     type: 'filterResponse',
-    value: [0,1,2,3,4,5],
-    name: 'c'
-  }
-
+    value: [0, 1, 2, 3, 4, 5],
+    name: 'c',
+  };
 
   const ctrl = new CapabilitiesController({
     restrictedMethods: {
@@ -434,8 +433,8 @@ test('updateCaveatFor', async (t) => {
         method: (req, res, _next, end) => {
           res.result = req.params;
           end();
-        }
-      }
+        },
+      },
     },
 
     // All permissions automatically approved
@@ -444,8 +443,8 @@ test('updateCaveatFor', async (t) => {
     },
   },
   {
-    domains: {}
-  })
+    domains: {},
+  });
 
   try {
 
@@ -455,11 +454,11 @@ test('updateCaveatFor', async (t) => {
         {
           'testMethod': {
             caveats: [
-              { ...cav1 }, { ...cav2 }
-            ]
+              { ...cav1 }, { ...cav2 },
+            ],
           },
-        }
-      ]
+        },
+      ],
     };
 
     await sendRpcMethodWithResponse(ctrl, domain, req);
@@ -469,32 +468,32 @@ test('updateCaveatFor', async (t) => {
       try {
 
         ctrl.updateCaveatFor(
-          'foo.bar.xyz', 'testMethod', 'a', [0,1]
-        )
+          'foo.bar.xyz', 'testMethod', 'a', [0, 1]
+        );
 
-        t.notOk(true, 'should have thrown')
+        t.notOk(true, 'should have thrown');
 
       } catch (err) {
-        t.ok(err, 'did throw')
+        t.ok(err, 'did throw');
       }
-      t.end()
-    })
+      t.end();
+    });
 
     test('updateCaveatFor throws on non-existing method', async (t) => {
 
       try {
 
         ctrl.updateCaveatFor(
-          domain.origin, 'doesNotExist', 'a', [0,1]
-        )
+          domain.origin, 'doesNotExist', 'a', [0, 1]
+        );
 
-        t.notOk(true, 'should have thrown')
+        t.notOk(true, 'should have thrown');
 
       } catch (err) {
-        t.ok(err, 'did throw')
+        t.ok(err, 'did throw');
       }
-      t.end()
-    })
+      t.end();
+    });
 
     test('updateCaveatFor does not alter state after throwing', async (t) => {
 
@@ -503,58 +502,58 @@ test('updateCaveatFor', async (t) => {
         req = {
           method: 'testMethod',
           params: [],
-        }
+        };
         const result = await sendRpcMethodWithResponse(ctrl, domain, req);
 
         t.ok(result, 'should succeed');
-        t.deepEqual(result, [0,1,2,3], 'returned the correct subset');
+        t.deepEqual(result, [0, 1, 2, 3], 'returned the correct subset');
 
       } catch (err) {
-        t.notOk(err, 'should not throw')
+        t.notOk(err, 'should not throw');
       }
-      t.end()
-    })
+      t.end();
+    });
 
     test('updateCaveatFor successfully updates caveats', async (t) => {
 
       try {
 
-        cav1.value = [0,1,2]
+        cav1.value = [0, 1, 2];
 
         ctrl.updateCaveatFor(
           domain.origin, 'testMethod', 'a', cav1.value
-        )
+        );
 
         req = {
           method: 'testMethod',
           params: [],
-        }
+        };
         const result = await sendRpcMethodWithResponse(ctrl, domain, req);
 
         t.ok(result, 'should succeed');
-        t.deepEqual(result, [0,1,2], 'returned the correct subset');
+        t.deepEqual(result, [0, 1, 2], 'returned the correct subset');
 
       } catch (err) {
-        t.notOk(err, 'should not throw')
+        t.notOk(err, 'should not throw');
       }
-      t.end()
-    })
+      t.end();
+    });
 
     test('updateCaveatFor throws on non-existing caveat with valid name', async (t) => {
 
       try {
 
         ctrl.updateCaveatFor(
-          domain.origin, 'testMethod', 'b', [0,1]
-        )
+          domain.origin, 'testMethod', 'b', [0, 1]
+        );
 
-        t.notOk(true, 'should have thrown')
+        t.notOk(true, 'should have thrown');
 
       } catch (err) {
-        t.ok(err, 'did throw')
+        t.ok(err, 'did throw');
       }
-      t.end()
-    })
+      t.end();
+    });
 
     test('updateCaveatFor throws on existing caveat but different value type', async (t) => {
 
@@ -562,15 +561,15 @@ test('updateCaveatFor', async (t) => {
 
         ctrl.updateCaveatFor(
           domain.origin, 'testMethod', 'b', 'foo'
-        )
+        );
 
-        t.notOk(true, 'should have thrown')
+        t.notOk(true, 'should have thrown');
 
       } catch (err) {
-        t.ok(err, 'did throw')
+        t.ok(err, 'did throw');
       }
-      t.end()
-    })
+      t.end();
+    });
 
     test('final state after multiple updateCaveatFor calls', async (t) => {
 
@@ -579,32 +578,32 @@ test('updateCaveatFor', async (t) => {
         req = {
           method: 'testMethod',
           params: [],
-        }
+        };
         const result = await sendRpcMethodWithResponse(ctrl, domain, req);
 
         t.ok(result, 'should succeed');
-        t.deepEqual(result, [0,1,2], 'returned the correct subset');
+        t.deepEqual(result, [0, 1, 2], 'returned the correct subset');
 
-        const perms = ctrl.getPermissionsForDomain(domain.origin)
-        t.ok(perms.length === 1, 'expected number of permissions remain')
-        const { caveats } = perms[0]
-        t.ok(caveats.length === 2, 'expected number of caveats remain')
-        const c1 = caveats.find(p => p.name === 'a') 
-        t.deepEqual(c1, cav1, 'caveat "a" as expected')
-        const c2 = caveats.find(p => p.name === 'c')
-        t.deepEqual(c2, cav2, 'caveat "b" as expected')
+        const perms = ctrl.getPermissionsForDomain(domain.origin);
+        t.ok(perms.length === 1, 'expected number of permissions remain');
+        const { caveats } = perms[0];
+        t.ok(caveats.length === 2, 'expected number of caveats remain');
+        const c1 = caveats.find(p => p.name === 'a');
+        t.deepEqual(c1, cav1, 'caveat "a" as expected');
+        const c2 = caveats.find(p => p.name === 'c');
+        t.deepEqual(c2, cav2, 'caveat "b" as expected');
 
       } catch (err) {
-        t.notOk(err, 'should not throw')
+        t.notOk(err, 'should not throw');
       }
-      t.end()
-    })
+      t.end();
+    });
 
   } catch (err) {
     t.notOk(err, 'should not throw');
   }
   t.end();
-})
+});
 
 test('addCaveatFor', async (t) => {
 
@@ -612,16 +611,15 @@ test('addCaveatFor', async (t) => {
 
   const cav1 = {
     type: 'forceParams',
-    value: [0,1,2,3],
-    name: 'a'
-  }
+    value: [0, 1, 2, 3],
+    name: 'a',
+  };
 
   const cav2 = {
     type: 'filterResponse',
-    value: [0,1,2,3,4,5],
-    name: 'c'
-  }
-
+    value: [0, 1, 2, 3, 4, 5],
+    name: 'c',
+  };
 
   const ctrl = new CapabilitiesController({
     restrictedMethods: {
@@ -629,8 +627,8 @@ test('addCaveatFor', async (t) => {
         method: (req, res, _next, end) => {
           res.result = req.params;
           end();
-        }
-      }
+        },
+      },
     },
 
     // All permissions automatically approved
@@ -639,8 +637,8 @@ test('addCaveatFor', async (t) => {
     },
   },
   {
-    domains: {}
-  })
+    domains: {},
+  });
 
   try {
 
@@ -650,11 +648,11 @@ test('addCaveatFor', async (t) => {
         {
           'testMethod': {
             caveats: [
-              { ...cav1 }, { ...cav2 }
-            ]
+              { ...cav1 }, { ...cav2 },
+            ],
           },
-        }
-      ]
+        },
+      ],
     };
 
     await sendRpcMethodWithResponse(ctrl, domain, req);
@@ -666,18 +664,18 @@ test('addCaveatFor', async (t) => {
         ctrl.addCaveatFor(
           'foo.bar.xyz', 'testMethod', {
             type: 'forceParams',
-            value: [0,1],
-            name: 'a'
+            value: [0, 1],
+            name: 'a',
           }
-        )
+        );
 
-        t.notOk(true, 'should have thrown')
+        t.notOk(true, 'should have thrown');
 
       } catch (err) {
-        t.ok(err, 'did throw')
+        t.ok(err, 'did throw');
       }
-      t.end()
-    })
+      t.end();
+    });
 
     test('addCaveatFor throws on non-existing method', async (t) => {
 
@@ -686,18 +684,18 @@ test('addCaveatFor', async (t) => {
         ctrl.addCaveatFor(
           domain.origin, 'doesNotExist', {
             type: 'forceParams',
-            value: [0,1],
-            name: 'a'
+            value: [0, 1],
+            name: 'a',
           }
-        )
+        );
 
-        t.notOk(true, 'should have thrown')
+        t.notOk(true, 'should have thrown');
 
       } catch (err) {
-        t.ok(err, 'did throw')
+        t.ok(err, 'did throw');
       }
-      t.end()
-    })
+      t.end();
+    });
 
     test('addCaveatFor does not alter state after throwing', async (t) => {
 
@@ -706,17 +704,17 @@ test('addCaveatFor', async (t) => {
         req = {
           method: 'testMethod',
           params: [],
-        }
+        };
         const result = await sendRpcMethodWithResponse(ctrl, domain, req);
 
         t.ok(result, 'should succeed');
-        t.deepEqual(result, [0,1,2,3], 'returned the correct subset');
+        t.deepEqual(result, [0, 1, 2, 3], 'returned the correct subset');
 
       } catch (err) {
-        t.notOk(err, 'should not throw')
+        t.notOk(err, 'should not throw');
       }
-      t.end()
-    })
+      t.end();
+    });
 
     test('addCaveatFor successfully adds caveats', async (t) => {
 
@@ -726,24 +724,24 @@ test('addCaveatFor', async (t) => {
           domain.origin, 'testMethod', {
             type: 'forceParams',
             value: cav1.value,
-            name: 'b'
+            name: 'b',
           }
-        )
+        );
 
         req = {
           method: 'testMethod',
           params: [],
-        }
+        };
         const result = await sendRpcMethodWithResponse(ctrl, domain, req);
 
         t.ok(result, 'should succeed');
         t.deepEqual(result, cav1.value, 'returned the correct subset');
 
       } catch (err) {
-        t.notOk(err, 'should not throw')
+        t.notOk(err, 'should not throw');
       }
-      t.end()
-    })
+      t.end();
+    });
 
     test('addCaveatFor throws on adding existing name', async (t) => {
 
@@ -752,18 +750,18 @@ test('addCaveatFor', async (t) => {
         ctrl.addCaveatFor(
           domain.origin, 'testMethod', {
             type: 'forceParams',
-            value: [0,1],
-            name: 'b'
+            value: [0, 1],
+            name: 'b',
           }
-        )
+        );
 
-        t.notOk(true, 'should have thrown')
+        t.notOk(true, 'should have thrown');
 
       } catch (err) {
-        t.ok(err, 'did throw')
+        t.ok(err, 'did throw');
       }
-      t.end()
-    })
+      t.end();
+    });
 
     test('final state after multiple addCaveatFor calls', async (t) => {
 
@@ -772,34 +770,34 @@ test('addCaveatFor', async (t) => {
         req = {
           method: 'testMethod',
           params: [],
-        }
+        };
         const result = await sendRpcMethodWithResponse(ctrl, domain, req);
 
         t.ok(result, 'should succeed');
         t.deepEqual(result, cav1.value, 'returned the correct subset');
 
-        const perms = ctrl.getPermissionsForDomain(domain.origin)
-        t.ok(perms.length === 1, 'has expected number of permissions')
-        const { caveats } = perms[0]
-        t.ok(caveats.length === 3, 'has expected number of caveats')
-        let cav = caveats.find(p => p.name === 'a') 
-        t.deepEqual(cav, cav1, 'caveat "a" as expected')
-        cav = caveats.find(p => p.name === 'b') 
-        t.deepEqual(cav, { ...cav1, name: 'b' }, 'caveat "b" as expected')
-        cav = caveats.find(p => p.name === 'c')
-        t.deepEqual(cav, cav2, 'caveat "c" as expected')
+        const perms = ctrl.getPermissionsForDomain(domain.origin);
+        t.ok(perms.length === 1, 'has expected number of permissions');
+        const { caveats } = perms[0];
+        t.ok(caveats.length === 3, 'has expected number of caveats');
+        let cav = caveats.find(p => p.name === 'a');
+        t.deepEqual(cav, cav1, 'caveat "a" as expected');
+        cav = caveats.find(p => p.name === 'b');
+        t.deepEqual(cav, { ...cav1, name: 'b' }, 'caveat "b" as expected');
+        cav = caveats.find(p => p.name === 'c');
+        t.deepEqual(cav, cav2, 'caveat "c" as expected');
 
       } catch (err) {
-        t.notOk(err, 'should not throw')
+        t.notOk(err, 'should not throw');
       }
-      t.end()
-    })
+      t.end();
+    });
 
   } catch (err) {
     t.notOk(err, 'should not throw');
   }
   t.end();
-})
+});
 
 test('caveat getters', async (t) => {
 
@@ -807,16 +805,15 @@ test('caveat getters', async (t) => {
 
   const cav1 = {
     type: 'forceParams',
-    value: [0,1,2,3],
-    name: 'a'
-  }
+    value: [0, 1, 2, 3],
+    name: 'a',
+  };
 
   const cav2 = {
     type: 'filterResponse',
-    value: [0,1,2,3,4,5],
-    name: 'c'
-  }
-
+    value: [0, 1, 2, 3, 4, 5],
+    name: 'c',
+  };
 
   const ctrl = new CapabilitiesController({
     restrictedMethods: {
@@ -824,8 +821,8 @@ test('caveat getters', async (t) => {
         method: (req, res, _next, end) => {
           res.result = req.params;
           end();
-        }
-      }
+        },
+      },
     },
 
     // All permissions automatically approved
@@ -834,22 +831,22 @@ test('caveat getters', async (t) => {
     },
   },
   {
-    domains: {}
-  })
+    domains: {},
+  });
 
   try {
 
-    let req = {
+    const req = {
       method: 'requestPermissions',
       params: [
         {
           'testMethod': {
             caveats: [
-              { ...cav1 }, { ...cav2 }
-            ]
+              { ...cav1 }, { ...cav2 },
+            ],
           },
-        }
-      ]
+        },
+      ],
     };
 
     await sendRpcMethodWithResponse(ctrl, domain, req);
@@ -860,15 +857,15 @@ test('caveat getters', async (t) => {
 
         const cav = ctrl.getCaveat(
           domain.origin, 'testMethod', 'a'
-        )
+        );
 
-        t.deepEqual(cav, cav1)
+        t.deepEqual(cav, cav1);
 
       } catch (err) {
-        t.notOk(err, 'should not throw')
+        t.notOk(err, 'should not throw');
       }
-      t.end()
-    })
+      t.end();
+    });
 
     test('getCaveats retrieves all caveats', async (t) => {
 
@@ -876,19 +873,19 @@ test('caveat getters', async (t) => {
 
         const caveats = ctrl.getCaveats(
           domain.origin, 'testMethod'
-        )
+        );
 
-        t.ok(caveats.length === 2, 'has expected number of caveats')
-        let cav = caveats.find(p => p.name === 'a') 
-        t.deepEqual(cav, cav1, 'caveat "a" as expected')
-        cav = caveats.find(p => p.name === 'c')
-        t.deepEqual(cav, cav2, 'caveat "c" as expected')
+        t.ok(caveats.length === 2, 'has expected number of caveats');
+        let cav = caveats.find(p => p.name === 'a');
+        t.deepEqual(cav, cav1, 'caveat "a" as expected');
+        cav = caveats.find(p => p.name === 'c');
+        t.deepEqual(cav, cav2, 'caveat "c" as expected');
 
       } catch (err) {
-        t.notOk(err, 'should not throw')
+        t.notOk(err, 'should not throw');
       }
-      t.end()
-    })
+      t.end();
+    });
 
     test('getting caveat(s) for unknown domain returns undefined', async (t) => {
 
@@ -896,18 +893,18 @@ test('caveat getters', async (t) => {
 
         let cav = ctrl.getCaveat(
           'not.a.known.domain', 'testMethod', 'a'
-        )
-        t.ok(cav === undefined, 'getCaveat returned undefined')
+        );
+        t.ok(cav === undefined, 'getCaveat returned undefined');
         cav = ctrl.getCaveats(
           'not.a.known.domain', 'testMethod'
-        )
-        t.ok(cav === undefined, 'getCaveats returned undefined')
+        );
+        t.ok(cav === undefined, 'getCaveats returned undefined');
 
       } catch (err) {
-        t.notOk(err, 'should not throw')
+        t.notOk(err, 'should not throw');
       }
-      t.end()
-    })
+      t.end();
+    });
 
     test('getting caveat(s) for unknown method returns undefined', async (t) => {
 
@@ -915,36 +912,36 @@ test('caveat getters', async (t) => {
 
         let cav = ctrl.getCaveat(
           domain.origin, 'unknownMethod', 'a'
-        )
-        t.ok(cav === undefined, 'getCaveat returned undefined')
+        );
+        t.ok(cav === undefined, 'getCaveat returned undefined');
         cav = ctrl.getCaveats(
           domain.origin, 'unknownMethod'
-        )
-        t.ok(cav === undefined, 'getCaveats returned undefined')
+        );
+        t.ok(cav === undefined, 'getCaveats returned undefined');
 
       } catch (err) {
-        t.notOk(err, 'should not throw')
+        t.notOk(err, 'should not throw');
       }
-      t.end()
-    })
+      t.end();
+    });
 
     test('getCaveat for unknown caveat name returns undefined', async (t) => {
 
       try {
 
-        let cav = ctrl.getCaveat(
+        const cav = ctrl.getCaveat(
           domain.origin, 'testMethod', 'unknownName'
-        )
-        t.ok(cav === undefined, 'getCaveat returned undefined')
+        );
+        t.ok(cav === undefined, 'getCaveat returned undefined');
 
       } catch (err) {
-        t.notOk(err, 'should not throw')
+        t.notOk(err, 'should not throw');
       }
-      t.end()
-    })
+      t.end();
+    });
 
   } catch (err) {
     t.notOk(err, 'should not throw');
   }
   t.end();
-})
+});

--- a/test/dependentPermissions.js
+++ b/test/dependentPermissions.js
@@ -1,4 +1,4 @@
-const test = require('tape')
+const test = require('tape');
 const CapabilitiesController = require('../dist').CapabilitiesController;
 const JsonRpcEngine = require('json-rpc-engine');
 
@@ -11,18 +11,18 @@ test('restricted permission gets restricted provider', async (t) => {
     requestUserApproval: (reqPerms) => Promise.resolve(reqPerms.permissions),
 
     restrictedMethods: {
-    
+
       'getName': {
         description: 'Returns user name',
-        method: (req, res, next, end) => {
+        method: (_req, res, _next, end) => {
           res.result = name;
           end();
-        }
+        },
       },
 
       'greet': {
         description: 'Greets the current name, if allowed.',
-        method: (req, res, next, end, engine) => {
+        method: (_req, res, _next, end, engine) => {
           engine.handle({ method: 'getName' }, (err, nameRes) => {
             if (err) {
               res.error = err;
@@ -31,19 +31,19 @@ test('restricted permission gets restricted provider', async (t) => {
             const gotName = nameRes.result;
             res.result = `Greetings, ${gotName}`;
             end();
-          })
-        }
+          });
+        },
       },
     },
-  })
+  });
 
-  const domain = { origin: 'login.metamask.io' }
-  let req = { method: 'greet' }
+  const domain = { origin: 'login.metamask.io' };
+  const req = { method: 'greet' };
 
   try {
-    let res = await sendRpcMethodWithResponse(ctrl, domain, req);
+    await sendRpcMethodWithResponse(ctrl, domain, req);
 
-    t.fail('should not complete successfully.')
+    t.fail('should not complete successfully.');
     t.end();
 
   } catch (error) {
@@ -52,7 +52,6 @@ test('restricted permission gets restricted provider', async (t) => {
     t.end();
   }
 });
-
 
 test('restricted permission gets domain permissions', async (t) => {
   const name = 'Glen Runciter';
@@ -63,53 +62,53 @@ test('restricted permission gets domain permissions', async (t) => {
     requestUserApproval: (reqPerms) => Promise.resolve(reqPerms.permissions),
 
     restrictedMethods: {
-    
+
       'getName': {
         description: 'Returns user name',
-        method: (req, res, next, end) => {
+        method: (_req, res, _next, end) => {
           res.result = name;
           end();
-        }
+        },
       },
 
       'greet': {
         description: 'Greets the current name, if allowed.',
-        method: (req, res, next, end, engine) => {
+        method: (_req, res, _next, end, engine) => {
           engine.handle({ method: 'getName' }, (err, nameRes) => {
             if (err) {
-              res.error = reason;
-              return end(reason);
+              res.error = err;
+              return end(err);
             }
             const gotName = nameRes.result;
             res.result = `Greetings, ${gotName}`;
             end();
-          })
-        }
+          });
+        },
       },
     },
-  })
+  });
 
-  const domain = { origin: 'login.metamask.io' }
+  const domain = { origin: 'login.metamask.io' };
 
-  let permReq = {
+  const permReq = {
     method: 'requestPermissions',
     params: [
-      { 
+      {
         getName: {},
         greet: {},
-      }
-    ]
-  }
+      },
+    ],
+  };
 
-  let req = { method: 'greet' }
+  const req = { method: 'greet' };
 
   try {
     await sendRpcMethodWithResponse(ctrl, domain, permReq);
-    let res = await sendRpcMethodWithResponse(ctrl, domain, req);
+    const res = await sendRpcMethodWithResponse(ctrl, domain, req);
 
-    t.ok(res, 'should complete successfully.')
-    t.ok(res.result.includes(name), 'greeting included name')
-    t.notEqual(res.result.indexOf(name), 0, 'Name is not beginning.')
+    t.ok(res, 'should complete successfully.');
+    t.ok(res.result.includes(name), 'greeting included name');
+    t.notEqual(res.result.indexOf(name), 0, 'Name is not beginning.');
     t.end();
 
   } catch (error) {
@@ -122,7 +121,7 @@ test('permitted provider can pass through to other methods', async (t) => {
   const name = 'Glen Runciter';
   const domain = { origin: 'login.metamask.io' };
 
-  const getNameMiddleware = (req, res, next, end) => {
+  const getNameMiddleware = (_req, res, _next, end) => {
     res.result = name;
     end();
   };
@@ -140,27 +139,25 @@ test('permitted provider can pass through to other methods', async (t) => {
     safeMethods: ['getName'],
 
     restrictedMethods: {
-    
-      
       'greet': {
         description: 'Greets the current name, if allowed.',
-        method: (req, res, next, end, engine) => {
+        method: (_req, res, _next, end, engine) => {
           engine.handle({ method: 'getName' }, (err, nameRes) => {
             if (err) {
-              res.error = reason;
-              return end(reason);
+              res.error = err;
+              return end(err);
             }
             const gotName = nameRes.result;
             res.result = `Greetings, ${gotName}`;
             end();
-          })
-        }
+          });
+        },
       },
     },
-  })
+  });
 
   const engine = new JsonRpcEngine();
-  engine.push(ctrl.providerMiddlewareFunction.bind(ctrl, domain))
+  engine.push(ctrl.providerMiddlewareFunction.bind(ctrl, domain));
   engine.push(getNameMiddleware);
 
   function send (request) {
@@ -170,27 +167,27 @@ test('permitted provider can pass through to other methods', async (t) => {
           rej(err || result.error);
         }
         res(result);
-      })
+      });
     });
   }
 
   const permReq = {
     method: 'requestPermissions',
     params: [
-      { 
+      {
         greet: {},
-      }
-    ]
+      },
+    ],
   };
-  let req = { method: 'greet' };
+  const req = { method: 'greet' };
 
   try {
     await send(permReq);
-    let res = await send(req);
+    const res = await send(req);
 
-    t.ok(res, 'should complete successfully.')
-    t.ok(res.result.includes(name), 'greeting included name')
-    t.notEqual(res.result.indexOf(name), 0, 'Name is not beginning.')
+    t.ok(res, 'should complete successfully.');
+    t.ok(res.result.includes(name), 'greeting included name');
+    t.notEqual(res.result.indexOf(name), 0, 'Name is not beginning.');
     t.end();
 
   } catch (error) {
@@ -199,25 +196,24 @@ test('permitted provider can pass through to other methods', async (t) => {
   }
 });
 
-async function sendRpcMethodWithResponse(ctrl, domain, req) {
-  let res = {}
+async function sendRpcMethodWithResponse (ctrl, domain, req) {
+  const res = {};
   return new Promise((resolve, reject) => {
-    ctrl.providerMiddlewareFunction(domain, req, res, next, end)
+    ctrl.providerMiddlewareFunction(domain, req, res, next, end);
 
-    function next() {
-      reject()
+    function next () {
+      reject();
     }
 
-    function end(reason) {
+    function end (reason) {
       if (reason) {
-        reject(reason)
+        reject(reason);
       }
       if (res.error) {
-        reject(res.error)
+        reject(res.error);
       }
 
-      resolve(res)
+      resolve(res);
     }
-  })
+  });
 }
-

--- a/test/forwarding.js
+++ b/test/forwarding.js
@@ -1,39 +1,39 @@
 const test = require('tape');
-const CapabilitiesController = require('../dist').CapabilitiesController
+const CapabilitiesController = require('../dist').CapabilitiesController;
 
-const UNAUTHORIZED_CODE = require('eth-json-rpc-errors').ERROR_CODES.provider.unauthorized
-const METHOD_NOT_FOUND_CODE = require('eth-json-rpc-errors').ERROR_CODES.rpc.methodNotFound
+const UNAUTHORIZED_CODE = require('eth-json-rpc-errors').ERROR_CODES.provider.unauthorized;
+const METHOD_NOT_FOUND_CODE = require('eth-json-rpc-errors').ERROR_CODES.rpc.methodNotFound;
 
 test('safe method should pass through', async (t) => {
-  const WRITE_RESULT = 'impeccable result'
+  const WRITE_RESULT = 'impeccable result';
 
   const ctrl = new CapabilitiesController({
     safeMethods: ['public_read'],
     requestUserApproval: async (permsReq) => permsReq.permissions,
-  }, {})
+  }, {});
 
-  const domain = {origin: 'login.metamask.io'}
-  let req = { method: 'public_read' }
-  let res = {}
+  const domain = { origin: 'login.metamask.io' };
+  const req = { method: 'public_read' };
+  const res = {};
 
-  ctrl.providerMiddlewareFunction(domain, req, res, next, end)
+  ctrl.providerMiddlewareFunction(domain, req, res, next, end);
 
-  function next() {
-    t.ok(true, 'next was called')
-    t.end()
+  function next () {
+    t.ok(true, 'next was called');
+    t.end();
   }
 
-  function end(reason) {
-    t.error(reason, 'error thrown')
-    t.equal(res.result, WRITE_RESULT)
-    t.end()
+  function end (reason) {
+    t.error(reason, 'error thrown');
+    t.equal(res.result, WRITE_RESULT);
+    t.end();
   }
 
-})
+});
 
 test('requesting restricted method is rejected', async (t) => {
-  const WRITE_RESULT = 'impeccable result'
-  const domain = {origin: 'login.metamask.io'}
+  const WRITE_RESULT = 'impeccable result';
+  const domain = { origin: 'login.metamask.io' };
 
   const ctrl = new CapabilitiesController({
 
@@ -47,41 +47,41 @@ test('requesting restricted method is rejected', async (t) => {
 
     restrictedMethods: {
       'eth_write': {
-        method: (req, res, next, end) => {
-          res.result = WRITE_RESULT
-        }
-      }
+        method: (_req, res, _next, _end) => {
+          res.result = WRITE_RESULT;
+        },
+      },
     },
 
     requestUserApproval: async (permsReq) => permsReq.permissions,
-},
-{
-  domains: {}
-})
+  },
+  {
+    domains: {},
+  });
 
-  let req = { method: 'eth_write' }
-  let res = {}
-  ctrl.providerMiddlewareFunction(domain, req, res, next, end)
+  const req = { method: 'eth_write' };
+  const res = {};
+  ctrl.providerMiddlewareFunction(domain, req, res, next, end);
 
-  function next() {
-    t.ok(false, 'next should not be called')
-    t.end()
+  function next () {
+    t.ok(false, 'next should not be called');
+    t.end();
   }
 
-  function end(reason) {
-    t.ok(reason, 'error should be thrown')
-    t.ok(res.error, 'should have error object')
-    t.equal(reason.code, UNAUTHORIZED_CODE, `error code should be ${UNAUTHORIZED_CODE}.`)
-    t.equal(res.error.code, UNAUTHORIZED_CODE, `error code should be ${UNAUTHORIZED_CODE}.`)
-    t.notEqual(res.result, WRITE_RESULT, 'should not have complete result.')
-    t.end()
+  function end (reason) {
+    t.ok(reason, 'error should be thrown');
+    t.ok(res.error, 'should have error object');
+    t.equal(reason.code, UNAUTHORIZED_CODE, `error code should be ${UNAUTHORIZED_CODE}.`);
+    t.equal(res.error.code, UNAUTHORIZED_CODE, `error code should be ${UNAUTHORIZED_CODE}.`);
+    t.notEqual(res.result, WRITE_RESULT, 'should not have complete result.');
+    t.end();
   }
 
-})
+});
 
 test('requesting unknown method is rejected', async (t) => {
-  const WRITE_RESULT = 'impeccable result'
-  const domain = {origin: 'login.metamask.io'}
+  const WRITE_RESULT = 'impeccable result';
+  const domain = { origin: 'login.metamask.io' };
 
   const ctrl = new CapabilitiesController({
 
@@ -95,41 +95,41 @@ test('requesting unknown method is rejected', async (t) => {
 
     restrictedMethods: {
       'eth_write': {
-        method: (req, res, next, end) => {
-          res.result = WRITE_RESULT
-        }
-      }
+        method: (_req, res, _next, _end) => {
+          res.result = WRITE_RESULT;
+        },
+      },
     },
 
     requestUserApproval: async (permsReq) => permsReq.permissions,
-},
-{
-  domains: {}
-})
+  },
+  {
+    domains: {},
+  });
 
-  let req = { method: 'fooBar' }
-  let res = {}
-  ctrl.providerMiddlewareFunction(domain, req, res, next, end)
+  const req = { method: 'fooBar' };
+  const res = {};
+  ctrl.providerMiddlewareFunction(domain, req, res, next, end);
 
-  function next() {
-    t.ok(false, 'next should not be called')
-    t.end()
+  function next () {
+    t.ok(false, 'next should not be called');
+    t.end();
   }
 
-  function end(reason) {
-    t.ok(reason, 'error should be thrown')
-    t.ok(res.error, 'should have error object')
-    t.equal(reason.code, METHOD_NOT_FOUND_CODE, `error code should be ${METHOD_NOT_FOUND_CODE}.`)
-    t.equal(res.error.code, METHOD_NOT_FOUND_CODE, `error code should be ${METHOD_NOT_FOUND_CODE}.`)
-    t.notEqual(res.result, WRITE_RESULT, 'should not have complete result.')
-    t.end()
+  function end (reason) {
+    t.ok(reason, 'error should be thrown');
+    t.ok(res.error, 'should have error object');
+    t.equal(reason.code, METHOD_NOT_FOUND_CODE, `error code should be ${METHOD_NOT_FOUND_CODE}.`);
+    t.equal(res.error.code, METHOD_NOT_FOUND_CODE, `error code should be ${METHOD_NOT_FOUND_CODE}.`);
+    t.notEqual(res.result, WRITE_RESULT, 'should not have complete result.');
+    t.end();
   }
 
-})
+});
 
 test('requesting restricted method with permission is called', async (t) => {
-  const WRITE_RESULT = 'impeccable result'
-  const domain = {origin: 'login.metamask.io'}
+  const WRITE_RESULT = 'impeccable result';
+  const domain = { origin: 'login.metamask.io' };
 
   const ctrl = new CapabilitiesController({
 
@@ -142,11 +142,11 @@ test('requesting restricted method with permission is called', async (t) => {
     methodPrefix: 'wallet_',
     restrictedMethods: {
       'eth_write': {
-        method: (req, res, next, end) => {
-          res.result = WRITE_RESULT
-          return end()
-        }
-      }
+        method: (_req, res, _next, end) => {
+          res.result = WRITE_RESULT;
+          return end();
+        },
+      },
     },
     requestUserApproval: async (permsReq) => permsReq.permissions,
   },
@@ -157,43 +157,42 @@ test('requesting restricted method with permission is called', async (t) => {
           {
             parentCapability: 'eth_write',
             date: '0',
-          }
-        ]
-      }
-    }
-  })
+          },
+        ],
+      },
+    },
+  });
 
-  let req = { method: 'eth_write', params: ['hello!'] };
+  const req = { method: 'eth_write', params: ['hello!'] };
   try {
-    let res = await sendRpcMethodWithResponse(ctrl, domain, req);
-    t.error(res.error, 'should not have error object')
-    t.equal(res.result, WRITE_RESULT, 'Write result should be assigned.')
-    t.end()
+    const res = await sendRpcMethodWithResponse(ctrl, domain, req);
+    t.error(res.error, 'should not have error object');
+    t.equal(res.result, WRITE_RESULT, 'Write result should be assigned.');
+    t.end();
   } catch (error) {
     t.error(error, 'should not throw error');
     t.end();
   }
-})
+});
 
-async function sendRpcMethodWithResponse(ctrl, domain, req) {
-  let res = {}
+async function sendRpcMethodWithResponse (ctrl, domain, req) {
+  const res = {};
   return new Promise((resolve, reject) => {
-    ctrl.providerMiddlewareFunction(domain, req, res, next, end)
+    ctrl.providerMiddlewareFunction(domain, req, res, next, end);
 
-    function next() {
-      reject()
+    function next () {
+      reject();
     }
 
-    function end(reason) {
+    function end (reason) {
       if (reason) {
-        reject(reason)
+        reject(reason);
       }
       if (res.error) {
-        reject(res.error)
+        reject(res.error);
       }
 
-      resolve(res)
+      resolve(res);
     }
-  })
+  });
 }
-

--- a/test/getPermissions.js
+++ b/test/getPermissions.js
@@ -1,8 +1,8 @@
-const test = require('tape')
-const CapabilitiesController = require('../dist').CapabilitiesController
-const equal = require('fast-deep-equal')
+const test = require('tape');
+const CapabilitiesController = require('../dist').CapabilitiesController;
+const equal = require('fast-deep-equal');
 
-function noop () {};
+function noop () {}
 
 const arbitraryCaps = [
   {
@@ -17,35 +17,35 @@ const arbitraryCaps = [
     granter: 'bar',
     id: 'xyz',
   },
-]
+];
 
 test('getPermissions with none returns empty object', async (t) => {
-  const expected = []
+  const expected = [];
 
   const ctrl = new CapabilitiesController({
     requestUserApproval: noop,
-  })
+  });
 
-  const domain = {origin: 'login.metamask.io'}
-  let req = { method: 'getPermissions' }
-  let res = {}
+  const domain = { origin: 'login.metamask.io' };
+  const req = { method: 'getPermissions' };
+  const res = {};
 
-  ctrl.providerMiddlewareFunction(domain, req, res, next, end)
+  ctrl.providerMiddlewareFunction(domain, req, res, next, end);
 
-  function next() {
-    t.ok(false, 'next should not be called')
-    t.end()
+  function next () {
+    t.ok(false, 'next should not be called');
+    t.end();
   }
 
-  function end(reason) {
-    t.error(reason, 'error thrown')
-    t.ok(equal(res.result, expected), 'should be equal')
-    t.end()
+  function end (reason) {
+    t.error(reason, 'error thrown');
+    t.ok(equal(res.result, expected), 'should be equal');
+    t.end();
   }
-})
+});
 
 test('getPermissions with some returns them', async (t) => {
-  const expected = arbitraryCaps
+  const expected = arbitraryCaps;
 
   const ctrl = new CapabilitiesController({
     requestUserApproval: noop,
@@ -55,23 +55,23 @@ test('getPermissions with some returns them', async (t) => {
       'login.metamask.io': {
         permissions: expected,
       },
-    }
-  })
+    },
+  });
 
-  const domain = {origin: 'login.metamask.io'}
-  let req = { method: 'getPermissions' }
-  let res = {}
+  const domain = { origin: 'login.metamask.io' };
+  const req = { method: 'getPermissions' };
+  const res = {};
 
-  ctrl.providerMiddlewareFunction(domain, req, res, next, end)
+  ctrl.providerMiddlewareFunction(domain, req, res, next, end);
 
-  function next() {
-    t.ok(false, 'next should not be called')
-    t.end()
+  function next () {
+    t.ok(false, 'next should not be called');
+    t.end();
   }
 
-  function end(reason) {
-    t.error(reason, 'error thrown')
-    t.ok(equal(res.result, expected), 'should be equal')
-    t.end()
+  function end (reason) {
+    t.error(reason, 'error thrown');
+    t.ok(equal(res.result, expected), 'should be equal');
+    t.end();
   }
-})
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
-require('./forwarding')
-require('./getPermissions')
-require('./requestPermissions')
-require('./caveats')
-require('./wildcardPermissions')
-require('./dependentPermissions')
+require('./forwarding');
+require('./getPermissions');
+require('./requestPermissions');
+require('./caveats');
+require('./wildcardPermissions');
+require('./dependentPermissions');

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -1,6 +1,6 @@
 const RpcEngine = require('json-rpc-engine');
 
-async function sendRpcMethodWithResponse(ctrl, domain, req) {
+async function sendRpcMethodWithResponse (ctrl, domain, req) {
   return new Promise((resolve, reject) => {
     const engine = new RpcEngine();
     engine.push(ctrl.providerMiddlewareFunction.bind(ctrl, domain));
@@ -12,10 +12,10 @@ async function sendRpcMethodWithResponse(ctrl, domain, req) {
 
       resolve(res.result);
     });
-  })
+  });
 }
 
 module.exports = {
   sendRpcMethodWithResponse,
-}
+};
 

--- a/test/requestPermissions.js
+++ b/test/requestPermissions.js
@@ -1,128 +1,127 @@
-const test = require('tape')
+const test = require('tape');
 const CapabilitiesController = require('../dist').CapabilitiesController;
-const equal = require('fast-deep-equal')
-const rpcErrors = require('eth-json-rpc-errors')
+const equal = require('fast-deep-equal');
+const rpcErrors = require('eth-json-rpc-errors');
 
-const USER_REJECTION_CODE = rpcErrors.ERROR_CODES.provider.userRejectedRequest
-const INVALID_REQUEST_CODE = rpcErrors.ERROR_CODES.rpc.invalidRequest
+const USER_REJECTION_CODE = rpcErrors.ERROR_CODES.provider.userRejectedRequest;
+const INVALID_REQUEST_CODE = rpcErrors.ERROR_CODES.rpc.invalidRequest;
 
 test('requestPermissions with user rejection creates no permissions', async (t) => {
-  const expected = []
+  const expected = [];
 
   const ctrl = new CapabilitiesController({
     requestUserApproval: () => Promise.resolve({}),
     restrictedMethods: {
-      restricted: (req, res, next, end) => {
+      restricted: (_req, res, _next, end) => {
         res.result = 'Wahoo!';
         end();
-      }
-    }
-  })
+      },
+    },
+  });
 
-  const domain = { origin: 'login.metamask.io' }
-  let req = {
+  const domain = { origin: 'login.metamask.io' };
+  const req = {
     method: 'requestPermissions',
     params: [
-        {restricted: {}}
-    ]
-  }
-  let res = {}
+      { restricted: {} },
+    ],
+  };
+  const res = {};
 
-  ctrl.providerMiddlewareFunction(domain, req, res, next, end)
+  ctrl.providerMiddlewareFunction(domain, req, res, next, end);
 
-  function next() {
-    t.ok(false, 'next should not be called')
-    t.end()
+  function next () {
+    t.ok(false, 'next should not be called');
+    t.end();
   }
 
-  function end(reason) {
-    t.ok(reason, 'error thrown')
-    t.equal(reason.code, USER_REJECTION_CODE, 'Rejection error returned')
-    t.ok(equal(ctrl.getPermissionsForDomain(domain.origin), expected), 'should have no permissions still')
-    t.end()
+  function end (reason) {
+    t.ok(reason, 'error thrown');
+    t.equal(reason.code, USER_REJECTION_CODE, 'Rejection error returned');
+    t.ok(equal(ctrl.getPermissionsForDomain(domain.origin), expected), 'should have no permissions still');
+    t.end();
   }
-})
+});
 
 test('requestPermissions with invalid requested permissions object fails', async (t) => {
-  const expected = []
+  const expected = [];
 
   const ctrl = new CapabilitiesController({
     requestUserApproval: () => Promise.resolve({}),
     restrictedMethods: {
-      restricted: (req, res, next, end) => {
+      restricted: (_req, res, _next, end) => {
         res.result = 'Wahoo!';
         end();
-      }
-    }
-  })
+      },
+    },
+  });
 
-  const domain = { origin: 'login.metamask.io' }
-  let req = {
+  const domain = { origin: 'login.metamask.io' };
+  const req = {
     method: 'requestPermissions',
     params: [
-        { restricted: { parentCapability: 'foo' } }
-    ]
-  }
-  let res = {}
+      { restricted: { parentCapability: 'foo' } },
+    ],
+  };
+  const res = {};
 
-  ctrl.providerMiddlewareFunction(domain, req, res, next, end)
+  ctrl.providerMiddlewareFunction(domain, req, res, next, end);
 
-  function next() {
-    t.ok(false, 'next should not be called')
-    t.end()
+  function next () {
+    t.ok(false, 'next should not be called');
+    t.end();
   }
 
-  function end(reason) {
-    t.ok(reason, 'error thrown')
-    t.equal(reason.code, INVALID_REQUEST_CODE, 'Invalid request error returned')
-    t.ok(equal(ctrl.getPermissionsForDomain(domain.origin), expected), 'should have no permissions still')
-    t.end()
+  function end (reason) {
+    t.ok(reason, 'error thrown');
+    t.equal(reason.code, INVALID_REQUEST_CODE, 'Invalid request error returned');
+    t.ok(equal(ctrl.getPermissionsForDomain(domain.origin), expected), 'should have no permissions still');
+    t.end();
   }
-})
+});
 
 test('requestPermissions with user approval creates permission', async (t) => {
 
   const expected = {
-     domains: {
+    domains: {
       'login.metamask.io': {
         permissions: [{
-          restricted: {}
-        }]
-      }
-    }
-  }
-
+          restricted: {},
+        }],
+      },
+    },
+  };
 
   const ctrl = new CapabilitiesController({
     requestUserApproval: () => Promise.resolve(expected.domains['login.metamask.io'].permissions[0]),
     restrictedMethods: {
 
-      restricted: (req, res, next, end) => {
+      restricted: (_req, res, _next, end) => {
         res.result = 'Wahoo!';
         end();
-      }
-    }
-  })
+      },
+    },
+  });
 
-  const domain = { origin: 'login.metamask.io' }
-  let req = {
+  const domain = { origin: 'login.metamask.io' };
+  const req = {
     method: 'requestPermissions',
     params: [
       {
-        restricted: {}
-      }
-    ]
-  }
+        restricted: {},
+      },
+    ],
+  };
 
   try {
-    let res = await sendRpcMethodWithResponse(ctrl, domain, req);
-    const endState = ctrl.state
+    await sendRpcMethodWithResponse(ctrl, domain, req);
+    const endState = ctrl.state;
     const perms = endState.domains[domain.origin].permissions;
-    t.equal(perms[0].parentCapability, 'restricted', 'permission added.')
-    t.end()
+    t.equal(perms[0].parentCapability, 'restricted', 'permission added.');
+    t.end();
 
   } catch (error) {
-    t.error(error, 'error should not be thrown')
+    t.error(error, 'error should not be thrown');
     t.end();
   }
 });
@@ -132,53 +131,53 @@ test('approving unknown permission should fail', async (t) => {
   const ctrl = new CapabilitiesController({
     requestUserApproval: () => Promise.resolve({ unknownPerm: {} }),
     restrictedMethods: {
-      restricted: (req, res, next, end) => {
+      restricted: (_req, res, _next, end) => {
         res.result = 'Wahoo!';
         end();
-      }
-    }
-  })
+      },
+    },
+  });
 
-  const domain = { origin: 'login.metamask.io' }
-  let req = {
+  const domain = { origin: 'login.metamask.io' };
+  const req = {
     method: 'requestPermissions',
     params: [
       {
-        restricted: {}
-      }
-    ]
-  }
+        restricted: {},
+      },
+    ],
+  };
 
   try {
-    let res = await sendRpcMethodWithResponse(ctrl, domain, req);
+    const res = await sendRpcMethodWithResponse(ctrl, domain, req);
     t.notOk(res, 'should not resolve');
     t.end();
 
   } catch (error) {
-    t.ok(error, 'error should be thrown')
-    t.equal(error.code, -32601, 'should throw method not found error')
+    t.ok(error, 'error should be thrown');
+    t.equal(error.code, -32601, 'should throw method not found error');
     t.end();
   }
-})
+});
 
-async function sendRpcMethodWithResponse(ctrl, domain, req) {
-  let res = {}
+async function sendRpcMethodWithResponse (ctrl, domain, req) {
+  const res = {};
   return new Promise((resolve, reject) => {
-    ctrl.providerMiddlewareFunction(domain, req, res, next, end)
+    ctrl.providerMiddlewareFunction(domain, req, res, next, end);
 
-    function next() {
-      reject()
+    function next () {
+      reject();
     }
 
-    function end(reason) {
+    function end (reason) {
       if (reason) {
-        reject(reason)
+        reject(reason);
       }
       if (res.error) {
-        reject(res.error)
+        reject(res.error);
       }
 
-      resolve(res)
+      resolve(res);
     }
-  })
+  });
 }

--- a/test/wildcardPermissions.js
+++ b/test/wildcardPermissions.js
@@ -1,7 +1,7 @@
-const test = require('tape')
+const test = require('tape');
 const CapabilitiesController = require('../dist').CapabilitiesController;
 
-const UNAUTHORIZED_CODE = require('eth-json-rpc-errors').ERROR_CODES.provider.unauthorized
+const UNAUTHORIZED_CODE = require('eth-json-rpc-errors').ERROR_CODES.provider.unauthorized;
 
 test('requestPermissions on namespaced method with user approval creates permission', async (t) => {
 
@@ -16,37 +16,37 @@ test('requestPermissions on namespaced method with user approval creates permiss
       // This namespaced method simply returns the namespace suffix:
       'plugin_': {
         // We need to enhance this parameter to support more open-ended display:
-        description: "Permission to install plugin",
-        method: (req, res, next, end) => {
+        description: 'Permission to install plugin',
+        method: (req, res, _next, end) => {
           const parts = req.method.split('_');
           const second = parts[1];
           res.result = second;
           end();
-        }
-      }
+        },
+      },
     },
 
-  })
+  });
 
-  const domain = { origin: 'login.metamask.io' }
+  const domain = { origin: 'login.metamask.io' };
   let req = {
     method: 'requestPermissions',
     params: [
       {
-        plugin_A: {}
-      }
-    ]
-  }
+        plugin_A: {},
+      },
+    ],
+  };
 
   try {
     let res = await sendRpcMethodWithResponse(ctrl, domain, req);
     req = { method: 'plugin_A' };
     res = await sendRpcMethodWithResponse(ctrl, domain, req);
     t.equal(res.result, 'A', 'returned the segment correctly.');
-    t.end()
+    t.end();
 
   } catch (error) {
-    t.error(error, 'error should not be thrown')
+    t.error(error, 'error should not be thrown');
     t.end();
   }
 });
@@ -61,37 +61,37 @@ test('requestPermissions on twice namespaced method with user approval creates p
     restrictedMethods: {
 
       'eth_plugin_': {
-        description: "Permission to install plugin",
-        method: (req, res, next, end) => {
+        description: 'Permission to install plugin',
+        method: (req, res, _next, end) => {
           const parts = req.method.split('_');
           const second = parts[2];
           res.result = second;
           end();
-        }
-      }
+        },
+      },
     },
 
-  })
+  });
 
-  const domain = { origin: 'login.metamask.io' }
+  const domain = { origin: 'login.metamask.io' };
   let req = {
     method: 'requestPermissions',
     params: [
       {
-        eth_plugin_A: {}
-      }
-    ]
-  }
+        eth_plugin_A: {},
+      },
+    ],
+  };
 
   try {
     let res = await sendRpcMethodWithResponse(ctrl, domain, req);
     req = { method: 'eth_plugin_A' };
     res = await sendRpcMethodWithResponse(ctrl, domain, req);
     t.equal(res.result, 'A', 'returned the segment correctly.');
-    t.end()
+    t.end();
 
   } catch (error) {
-    t.error(error, 'error should not be thrown')
+    t.error(error, 'error should not be thrown');
     t.end();
   }
 });
@@ -106,37 +106,37 @@ test('requestPermissions on namespaced method ending in a wildcard with user app
     restrictedMethods: {
 
       'eth_plugin_*': {
-        description: "Permission to install plugin",
-        method: (req, res, next, end) => {
+        description: 'Permission to install plugin',
+        method: (req, res, _next, end) => {
           const parts = req.method.split('_');
           const second = parts[2];
           res.result = second;
           end();
-        }
-      }
+        },
+      },
     },
 
-  })
+  });
 
-  const domain = { origin: 'login.metamask.io' }
+  const domain = { origin: 'login.metamask.io' };
   let req = {
     method: 'requestPermissions',
     params: [
       {
-        eth_plugin_A: {}
-      }
-    ]
-  }
+        eth_plugin_A: {},
+      },
+    ],
+  };
 
   try {
     let res = await sendRpcMethodWithResponse(ctrl, domain, req);
     req = { method: 'eth_plugin_A' };
     res = await sendRpcMethodWithResponse(ctrl, domain, req);
     t.equal(res.result, 'A', 'returned the segment correctly.');
-    t.end()
+    t.end();
 
   } catch (error) {
-    t.error(error, 'error should not be thrown')
+    t.error(error, 'error should not be thrown');
     t.end();
   }
 });
@@ -153,33 +153,33 @@ test('requestPermissions on namespaced method with user approval does not permit
       // Underscore suffix implies namespace:
       // This namespaced method simply returns the namespace suffix:
       'plugin_': {
-        method: (req, res, next, end) => {
+        method: (req, res, _next, end) => {
           const parts = req.method.split('_');
           const second = parts[1];
           res.result = second;
           end();
-        }
-      }
+        },
+      },
     },
 
-  })
+  });
 
-  const domain = { origin: 'login.metamask.io' }
+  const domain = { origin: 'login.metamask.io' };
   let req = {
     method: 'requestPermissions',
     params: [
       {
-        plugin_A: {}
-      }
-    ]
-  }
+        plugin_A: {},
+      },
+    ],
+  };
 
   try {
     let res = await sendRpcMethodWithResponse(ctrl, domain, req);
     req = { method: 'plugin_B' };
     res = await sendRpcMethodWithResponse(ctrl, domain, req);
     t.notOk(res, 'Should be restricted');
-    t.end()
+    t.end();
 
   } catch (error) {
     t.ok(error, 'error should not be thrown');
@@ -188,26 +188,24 @@ test('requestPermissions on namespaced method with user approval does not permit
   }
 });
 
-
-async function sendRpcMethodWithResponse(ctrl, domain, req) {
-  let res = {}
+async function sendRpcMethodWithResponse (ctrl, domain, req) {
+  const res = {};
   return new Promise((resolve, reject) => {
-    ctrl.providerMiddlewareFunction(domain, req, res, next, end)
+    ctrl.providerMiddlewareFunction(domain, req, res, next, end);
 
-    function next() {
-      reject()
+    function next () {
+      reject();
     }
 
-    function end(reason) {
+    function end (reason) {
       if (reason) {
-        reject(reason)
+        reject(reason);
       }
       if (res.error) {
-        reject(res.error)
+        reject(res.error);
       }
 
-      resolve(res)
+      resolve(res);
     }
-  })
+  });
 }
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -282,15 +282,15 @@ abstract-leveldown@~2.7.1:
   dependencies:
     xtend "~4.0.0"
 
-acorn-jsx@^5.0.0:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.2.tgz#84b68ea44b373c4f8686023a551f61a21b7c4a4f"
-  integrity sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==
+acorn-jsx@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.2.0.tgz#4c66069173d6fdd68ed85239fc256226182b2ebe"
+  integrity sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==
 
-acorn@^7.0.0:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
-  integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
+acorn@^7.1.1:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.2.0.tgz#17ea7e40d7c8640ff54a694c889c26f31704effe"
+  integrity sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==
 
 aes-js@^0.2.3:
   version "0.2.4"
@@ -344,7 +344,7 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.0.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
   integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
@@ -644,7 +644,7 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.1.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -652,6 +652,14 @@ chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+chalk@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
+  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
 
 chardet@^0.7.0:
   version "0.7.0"
@@ -996,13 +1004,6 @@ eslint-scope@^5.0.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-utils@^1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.2.tgz#166a5180ef6ab7eb462f162fd0e6f2463d7309ab"
-  integrity sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==
-  dependencies:
-    eslint-visitor-keys "^1.0.0"
-
 eslint-utils@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
@@ -1010,15 +1011,15 @@ eslint-utils@^1.4.3:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
+eslint-visitor-keys@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
-eslint@^6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.2.1.tgz#66c2e4fe8b6356b9f01e828adc3ad04030122df1"
-  integrity sha512-ES7BzEzr0Q6m5TK9i+/iTpKjclXitOdDK4vT07OqbkBT2/VcN/gO9EL1C4HlK3TAOXYv2ItcmbVR9jO1MR0fJg==
+eslint@6.8.0:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.8.0.tgz#62262d6729739f9275723824302fb227c8c93ffb"
+  integrity sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     ajv "^6.10.0"
@@ -1027,19 +1028,19 @@ eslint@^6.2.1:
     debug "^4.0.1"
     doctrine "^3.0.0"
     eslint-scope "^5.0.0"
-    eslint-utils "^1.4.2"
+    eslint-utils "^1.4.3"
     eslint-visitor-keys "^1.1.0"
-    espree "^6.1.0"
+    espree "^6.1.2"
     esquery "^1.0.1"
     esutils "^2.0.2"
     file-entry-cache "^5.0.1"
     functional-red-black-tree "^1.0.1"
     glob-parent "^5.0.0"
-    globals "^11.7.0"
+    globals "^12.1.0"
     ignore "^4.0.6"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
-    inquirer "^6.4.1"
+    inquirer "^7.0.0"
     is-glob "^4.0.0"
     js-yaml "^3.13.1"
     json-stable-stringify-without-jsonify "^1.0.1"
@@ -1048,7 +1049,7 @@ eslint@^6.2.1:
     minimatch "^3.0.4"
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
-    optionator "^0.8.2"
+    optionator "^0.8.3"
     progress "^2.0.0"
     regexpp "^2.0.1"
     semver "^6.1.2"
@@ -1058,13 +1059,13 @@ eslint@^6.2.1:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-espree@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-6.1.0.tgz#a1e8aa65bf29a331d70351ed814a80e7534e0884"
-  integrity sha512-boA7CHRLlVWUSg3iL5Kmlt/xT3Q+sXnKoRYYzj1YeM10A76TEJBbotV5pKbnK42hEUIr121zTv+QLRM5LsCPXQ==
+espree@^6.1.2:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-6.2.1.tgz#77fc72e1fd744a2052c20f38a5b575832e82734a"
+  integrity sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==
   dependencies:
-    acorn "^7.0.0"
-    acorn-jsx "^5.0.0"
+    acorn "^7.1.1"
+    acorn-jsx "^5.2.0"
     eslint-visitor-keys "^1.1.0"
 
 esprima@^4.0.0:
@@ -1601,7 +1602,7 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
   integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
 
-fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.4:
+fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
@@ -1800,10 +1801,17 @@ global@~4.3.0:
     min-document "^2.19.0"
     process "~0.5.1"
 
-globals@^11.1.0, globals@^11.7.0:
+globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
+
+globals@^12.1.0:
+  version "12.4.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-12.4.0.tgz#a18813576a41b00a24a97e7f815918c2e19925f8"
+  integrity sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==
+  dependencies:
+    type-fest "^0.8.1"
 
 graceful-fs@^4.1.15:
   version "4.2.2"
@@ -1979,23 +1987,23 @@ inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3, 
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-inquirer@^6.4.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.1.tgz#8bfb7a5ac02dac6ff641ac4c5ff17da112fcdb42"
-  integrity sha512-uxNHBeQhRXIoHWTSNYUFhQVrHYFThIt6IVo2fFmSe8aBwdR3/w6b58hJpiL/fMukFkvGzjg+hSxFtwvVmKZmXw==
+inquirer@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.1.0.tgz#1298a01859883e17c7264b82870ae1034f92dd29"
+  integrity sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==
   dependencies:
     ansi-escapes "^4.2.1"
-    chalk "^2.4.2"
+    chalk "^3.0.0"
     cli-cursor "^3.1.0"
     cli-width "^2.0.0"
     external-editor "^3.0.3"
     figures "^3.0.0"
     lodash "^4.17.15"
     mute-stream "0.0.8"
-    run-async "^2.2.0"
-    rxjs "^6.4.0"
+    run-async "^2.4.0"
+    rxjs "^6.5.3"
     string-width "^4.1.0"
-    strip-ansi "^5.1.0"
+    strip-ansi "^6.0.0"
     through "^2.3.6"
 
 intersect-objects@^1.0.0:
@@ -2049,11 +2057,6 @@ is-hex-prefixed@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz#7d8d37e6ad77e5d127148913c573e082d777f554"
   integrity sha1-fY035q135dEnFIkTxXPggtd39VQ=
-
-is-promise@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
-  integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
 
 is-regex@^1.0.4:
   version "1.0.4"
@@ -2642,17 +2645,17 @@ onetime@^5.1.0:
   dependencies:
     mimic-fn "^2.1.0"
 
-optionator@^0.8.2:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
-  integrity sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=
+optionator@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
+  integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
   dependencies:
     deep-is "~0.1.3"
-    fast-levenshtein "~2.0.4"
+    fast-levenshtein "~2.0.6"
     levn "~0.3.0"
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
-    wordwrap "~1.0.0"
+    word-wrap "~1.2.3"
 
 os-tmpdir@~1.0.2:
   version "1.0.2"
@@ -3017,22 +3020,20 @@ rlp@^2.0.0:
     bn.js "^4.11.1"
     safe-buffer "^5.1.1"
 
-run-async@^2.2.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
-  integrity sha1-A3GrSuC91yDUFm19/aZP96RFpsA=
-  dependencies:
-    is-promise "^2.1.0"
+run-async@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
+  integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
 
 rustbn.js@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/rustbn.js/-/rustbn.js-0.2.0.tgz#8082cb886e707155fd1cb6f23bd591ab8d55d0ca"
   integrity sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==
 
-rxjs@^6.4.0:
-  version "6.5.2"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.2.tgz#2e35ce815cd46d84d02a209fb4e5921e051dbec7"
-  integrity sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==
+rxjs@^6.5.3:
+  version "6.5.5"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
+  integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==
   dependencies:
     tslib "^1.9.0"
 
@@ -3457,7 +3458,7 @@ type-fest@^0.5.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.5.2.tgz#d6ef42a0356c6cd45f49485c3b6281fc148e48a2"
   integrity sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==
 
-type-fest@^0.8.0:
+type-fest@^0.8.0, type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
@@ -3598,10 +3599,10 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-wordwrap@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
-  integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
+word-wrap@~1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
+  integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
 wrap-ansi@^6.2.0:
   version "6.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1016,7 +1016,7 @@ eslint-visitor-keys@^1.1.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
   integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
-eslint@6.8.0:
+eslint@^6.8.0:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.8.0.tgz#62262d6729739f9275723824302fb227c8c93ffb"
   integrity sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==


### PR DESCRIPTION
- Lint every source file in the repo
  - We were previously only linting `index.ts`
  - Some overrides and inline rules had to be added to ensure that there were no breaking/functional changes
    - The state of this repo is still vastly improved
- Update `eslint` to `^6.8.0`

Should be completely non-functional.