### PR TITLE
v2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rpc-cap",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A module for adding an object-capabilities system to any JSON-RPC API as middleware for json-rpc-engine",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
`2.0.0` -> `2.1.0`

No update to `CHANGELOG.md`, because we've neglected it forever. Will create a new GH release, and we'll populate the changelog from the releases in a future PR.