### PR TITLE
Fix pending permission metadata.id generation

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -852,7 +852,6 @@ export class CapabilitiesController extends BaseController<any, any> implements 
     const requests = this.getPermissionsRequests();
 
     const permissionsRequest: IPermissionsRequest = {
-      origin: domain.origin,
       metadata: {
         origin: domain.origin,
         id,

--- a/index.ts
+++ b/index.ts
@@ -349,9 +349,10 @@ export class CapabilitiesController extends BaseController<any, any> implements 
   /**
    * Used for removing a permissions request from the permissions request array.
    *
-   * @param request The request that no longer requires user attention.
+   * @param requestId The id of the pending permissions request that no longer
+   * requires user attention.
    */
-  removePermissionsRequest (requestId: string): void {
+  removePermissionsRequest (requestId: string | number): void {
     const reqs = this.getPermissionsRequests().filter((oldReq) => {
       return oldReq.metadata.id !== requestId;
     });
@@ -829,7 +830,7 @@ export class CapabilitiesController extends BaseController<any, any> implements 
    * The capabilities middleware function used for requesting additional permissions from the user.
    */
   requestPermissionsMiddleware (
-    metadata: IOriginMetadata,
+    domain: IOriginMetadata,
     req: JsonRpcRequest<any>,
     res: JsonRpcResponse<any>,
     _next: JsonRpcEngineNextCallback,
@@ -843,16 +844,19 @@ export class CapabilitiesController extends BaseController<any, any> implements 
       return end(res.error);
     }
 
-    if (!metadata.id) {
-      metadata.id = uuid();
-    }
+    const id = typeof req.id === 'number' || req.id
+      ? req.id
+      : uuid();
 
     const permissions: IRequestedPermissions = req.params[0];
     const requests = this.getPermissionsRequests();
 
     const permissionsRequest: IPermissionsRequest = {
-      origin: metadata.origin,
-      metadata,
+      origin: domain.origin,
+      metadata: {
+        origin: domain.origin,
+        id,
+      },
       permissions: permissions,
     };
 
@@ -860,26 +864,20 @@ export class CapabilitiesController extends BaseController<any, any> implements 
     this.setPermissionsRequests(requests);
 
     this.requestUserApproval(permissionsRequest)
-    // TODO: Allow user to pass back an object describing
-    // the approved permissions, allowing user-customization.
       .then((approved: IRequestedPermissions) => {
         if (Object.keys(approved).length === 0) {
           res.error = userRejectedRequest(req);
           return end(res.error);
         }
-
-        // If user approval is different, use it as the permissions:
-        this.grantNewPermissions(metadata.origin, approved, res, end);
+        this.grantNewPermissions(domain.origin, approved, res, end);
       })
       .catch((reason) => {
         res.error = reason;
         return end(reason);
       })
       .finally(() => {
-      // Delete the request object
-        if (permissionsRequest.metadata.id) {
-          this.removePermissionsRequest(permissionsRequest.metadata.id);
-        }
+        // Delete the request object
+        this.removePermissionsRequest(permissionsRequest.metadata.id);
       });
   }
 }

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -1,8 +1,8 @@
 import {
   JsonRpcEngine,
-  JsonRpcMiddleware,
   JsonRpcEngineEndCallback,
   JsonRpcEngineNextCallback,
+  JsonRpcMiddleware,
   JsonRpcRequest,
   JsonRpcResponse,
 } from 'json-rpc-engine';
@@ -22,12 +22,16 @@ export type AuthenticatedJsonRpcMiddleware = (
  */
 export interface IPermissionsRequest {
   origin: string;
-  metadata: IOriginMetadata;
+  metadata: IPermissionsRequestMetadata ;
   permissions: IRequestedPermissions;
 }
 
+export interface IPermissionsRequestMetadata {
+  id: string | number;
+  origin: IOriginString;
+}
+
 export interface IOriginMetadata {
-  id?: string;
   origin: IOriginString;
 }
 

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -21,7 +21,6 @@ export type AuthenticatedJsonRpcMiddleware = (
  * Includes information about the domain granted, as well as the permissions assigned.
  */
 export interface IPermissionsRequest {
-  origin: string;
   metadata: IPermissionsRequestMetadata ;
   permissions: IRequestedPermissions;
 }


### PR DESCRIPTION
### Summary

Our generation of `id` values for pending permissions requests in `requestPermissionsMiddleware` was incorrect. This PR fixes it.

This is a prerequisite for solving: https://github.com/MetaMask/metamask-extension/issues/8919

### Details

The middleware functions of this package expect their first argument to be an `IOriginMetadata` object. The objects intended usage is made clear [by these lines in `providerMiddlewareFunction`](https://github.com/MetaMask/rpc-cap/blob/master/index.ts/#L186-L188). Specifically, it provides metadata about the external domain that the middleware is bound to.

We can see that our usage was incorrect, because we defaulted to the `IOriginMetadata` object's `id` property as the `metadata.id` property of the `IPermissionsRequest` object, which represents a pending permission. If the `IOriginMetadata` object did not have an id, it was set. _Since the `IOriginMetadata` object is bound to a middleware, once this `id` was set, it forced the same `metadata.id` value for all pending permissions request for that domain._ This breaks both methods internal to `rpc-cap`, like `removePermissionsRequest`, and functionality in the MetaMask Extension.

### Changes

- Rename `requestPermissionsMiddleware` `IOriginMetadata` parameter from `metadata` to `domain`, in line with other middleware methods
  - I believe that this misnaming of the parameter may have contributed to its incorrect use here and elsewhere
- For `IPermissionsRequest.metadata.id` values, default to the `req.id` value, and generate a `uuid()` as a fallback
- Type `IPermissionsRequest.metadata.id` values as `string | number`
  - This is because the types from `JsonRpcEngine` (which are in line with the JSON-RPC 2.0 spec), allow `string` and `number` `id` values
  - I would like to restrict the `id` types to `string` only, but that would require changes to `json-rpc-engine` and `@metamask/inpage-provider`. That can be done in follow-ups.
- Rationalize related types
  - Remove `id` property from `IOriginMetadata`
    - The `origin` is the `id`, and the `id` was never set beyond the case removed in this PR
  - Remove top-level `origin` property from `IPermissionsRequest`
    - The `metadata` property already has the `origin`, and that's also what's used in practice by the MetaMask extension
- Add relevant test case

#### `json-rpc-engine` IDs

`json-rpc-engine` generates its IDs [in this file](https://github.com/MetaMask/json-rpc-engine/blob/master/src/getUniqueId.js). We use its [ID remap middleware](https://github.com/MetaMask/json-rpc-engine/blob/master/src/idRemapMiddleware.js) in `@metamask/inpage-provider` to ensure that every request has a unique ID. I mention this just to note that the ID can take value `0`, and that the probability of collision is sufficiently low for our purposes.