### PR TITLE
Stringify permissions request IDs

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -352,7 +352,7 @@ export class CapabilitiesController extends BaseController<any, any> implements 
    * @param requestId The id of the pending permissions request that no longer
    * requires user attention.
    */
-  removePermissionsRequest (requestId: string | number): void {
+  removePermissionsRequest (requestId: string): void {
     const reqs = this.getPermissionsRequests().filter((oldReq) => {
       return oldReq.metadata.id !== requestId;
     });

--- a/index.ts
+++ b/index.ts
@@ -845,7 +845,7 @@ export class CapabilitiesController extends BaseController<any, any> implements 
     }
 
     const id = typeof req.id === 'number' || req.id
-      ? req.id
+      ? req.id.toString()
       : uuid();
 
     const permissions: IRequestedPermissions = req.params[0];

--- a/src/@types/index.d.ts
+++ b/src/@types/index.d.ts
@@ -26,7 +26,7 @@ export interface IPermissionsRequest {
 }
 
 export interface IPermissionsRequestMetadata {
-  id: string | number;
+  id: string;
   origin: IOriginString;
 }
 

--- a/test/requestPermissions.js
+++ b/test/requestPermissions.js
@@ -181,7 +181,7 @@ test('uses req.id as metadata.id of pending permissions request object', async (
   const ctrl = new CapabilitiesController({
     requestUserApproval: (permissionsRequest) => {
       t.equal(
-        permissionsRequest.metadata.id, requestIds[index],
+        permissionsRequest.metadata.id, requestIds[index].toString(),
         'permissions request object should have expected metadata.id'
       );
       if (index === requestIds.length - 1) {


### PR DESCRIPTION
- Stringify `req.id` when defaulting to it as a permissions request ID
- Change type of `IPermissionsRequest.id` from `string | number` to `string`