### PR TITLE
eth-rpc-errors@2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "clone": "^2.1.2",
-    "eth-json-rpc-errors": "^2.0.2",
+    "eth-rpc-errors": "^2.1.1",
     "fast-deep-equal": "^2.0.1",
     "gaba": "^1.9.3",
     "intersect-objects": "^1.0.0",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,8 +1,8 @@
 import { JsonRpcRequest } from 'json-rpc-engine';
 
-import { IEthErrors, IEthereumRpcError } from 'eth-json-rpc-errors/@types';
+import { IEthErrors, IEthereumRpcError } from 'eth-rpc-errors/@types';
 
-const ethErrors: IEthErrors = require('eth-json-rpc-errors').ethErrors;
+const ethErrors: IEthErrors = require('eth-rpc-errors').ethErrors;
 
 interface ErrorArg {
   message?: string;

--- a/test/caveats.js
+++ b/test/caveats.js
@@ -4,7 +4,7 @@ const test = require('tape');
 const CapabilitiesController = require('../dist').CapabilitiesController;
 const sendRpcMethodWithResponse = require('./lib/utils').sendRpcMethodWithResponse;
 
-const UNAUTHORIZED_CODE = require('eth-json-rpc-errors').ERROR_CODES.provider.unauthorized;
+const UNAUTHORIZED_CODE = require('eth-rpc-errors').ERROR_CODES.provider.unauthorized;
 
 test('requireParams caveat throws if caveat value is not a subset of params.', async (t) => {
   const domain = { origin: 'www.metamask.io' };

--- a/test/forwarding.js
+++ b/test/forwarding.js
@@ -1,8 +1,8 @@
 const test = require('tape');
 const CapabilitiesController = require('../dist').CapabilitiesController;
 
-const UNAUTHORIZED_CODE = require('eth-json-rpc-errors').ERROR_CODES.provider.unauthorized;
-const METHOD_NOT_FOUND_CODE = require('eth-json-rpc-errors').ERROR_CODES.rpc.methodNotFound;
+const UNAUTHORIZED_CODE = require('eth-rpc-errors').ERROR_CODES.provider.unauthorized;
+const METHOD_NOT_FOUND_CODE = require('eth-rpc-errors').ERROR_CODES.rpc.methodNotFound;
 
 test('safe method should pass through', async (t) => {
   const WRITE_RESULT = 'impeccable result';

--- a/test/requestPermissions.js
+++ b/test/requestPermissions.js
@@ -1,7 +1,7 @@
 const test = require('tape');
 const CapabilitiesController = require('../dist').CapabilitiesController;
 const equal = require('fast-deep-equal');
-const rpcErrors = require('eth-json-rpc-errors');
+const rpcErrors = require('eth-rpc-errors');
 
 const USER_REJECTION_CODE = rpcErrors.ERROR_CODES.provider.userRejectedRequest;
 const INVALID_REQUEST_CODE = rpcErrors.ERROR_CODES.rpc.invalidRequest;

--- a/test/wildcardPermissions.js
+++ b/test/wildcardPermissions.js
@@ -1,7 +1,7 @@
 const test = require('tape');
 const CapabilitiesController = require('../dist').CapabilitiesController;
 
-const UNAUTHORIZED_CODE = require('eth-json-rpc-errors').ERROR_CODES.provider.unauthorized;
+const UNAUTHORIZED_CODE = require('eth-rpc-errors').ERROR_CODES.provider.unauthorized;
 
 test('requestPermissions on namespaced method with user approval creates permission', async (t) => {
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1150,13 +1150,6 @@ eth-json-rpc-errors@^2.0.1:
   dependencies:
     fast-safe-stringify "^2.0.6"
 
-eth-json-rpc-errors@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/eth-json-rpc-errors/-/eth-json-rpc-errors-2.0.2.tgz#c1965de0301fe941c058e928bebaba2e1285e3c4"
-  integrity sha512-uBCRM2w2ewusRHGxN8JhcuOb2RN3ueAOYH/0BhqdFmQkZx5lj5+fLKTz0mIVOzd4FG5/kUksCzCD7eTEim6gaA==
-  dependencies:
-    fast-safe-stringify "^2.0.6"
-
 eth-json-rpc-filters@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/eth-json-rpc-filters/-/eth-json-rpc-filters-4.1.1.tgz#15277c66790236d85f798f4d7dc6bab99a798cd2"
@@ -1236,6 +1229,13 @@ eth-query@^2.1.0, eth-query@^2.1.2:
   dependencies:
     json-rpc-random-id "^1.0.0"
     xtend "^4.0.1"
+
+eth-rpc-errors@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/eth-rpc-errors/-/eth-rpc-errors-2.1.1.tgz#00a7d6c8a9c864a8ab7d0356be20964e5bee4b13"
+  integrity sha512-MY3zAa5ZF8hvgQu1HOF9agaK5GgigBRGpTJ8H0oVlE0NqMu13CW6syyjLXdeIDCGQTbUeHliU1z9dVmvMKx1Tg==
+  dependencies:
+    fast-safe-stringify "^2.0.6"
 
 eth-sig-util@^1.4.0, eth-sig-util@^1.4.2:
   version "1.4.2"


### PR DESCRIPTION
Replace `eth-json-rpc-errors` with the latest `eth-rpc-errors`.