### PR TITLE
Remove unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,19 +30,16 @@
     "@typescript-eslint/eslint-plugin": "^2.17.0",
     "@typescript-eslint/parser": "^2.17.0",
     "eslint": "^6.8.0",
+    "fast-deep-equal": "^2.0.1",
     "nyc": "^15.0.0",
     "tape": "^4.9.2",
     "typescript": "^3.7.5"
   },
   "dependencies": {
-    "clone": "^2.1.2",
     "eth-json-rpc-errors": "^2.0.2",
-    "fast-deep-equal": "^2.0.1",
     "gaba": "^1.9.3",
-    "intersect-objects": "^1.0.0",
     "is-subset": "^0.1.1",
     "json-rpc-engine": "^5.1.8",
-    "obs-store": "^4.0.3",
     "uuid": "^3.3.2"
   },
   "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1178,6 +1178,13 @@ eth-json-rpc-errors@^2.0.1:
   dependencies:
     fast-safe-stringify "^2.0.6"
 
+eth-json-rpc-errors@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/eth-json-rpc-errors/-/eth-json-rpc-errors-2.0.2.tgz#c1965de0301fe941c058e928bebaba2e1285e3c4"
+  integrity sha512-uBCRM2w2ewusRHGxN8JhcuOb2RN3ueAOYH/0BhqdFmQkZx5lj5+fLKTz0mIVOzd4FG5/kUksCzCD7eTEim6gaA==
+  dependencies:
+    fast-safe-stringify "^2.0.6"
+
 eth-json-rpc-filters@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/eth-json-rpc-filters/-/eth-json-rpc-filters-4.1.1.tgz#15277c66790236d85f798f4d7dc6bab99a798cd2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -707,7 +707,7 @@ cliui@^6.0.0:
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
 
-clone@^2.0.0, clone@^2.1.1, clone@^2.1.2:
+clone@^2.0.0, clone@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
   integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
@@ -2005,11 +2005,6 @@ inquirer@^7.0.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
     through "^2.3.6"
-
-intersect-objects@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/intersect-objects/-/intersect-objects-1.0.0.tgz#b7630d28994b89b0f04d44728106136549ce816e"
-  integrity sha512-MS1xypHKJhWopnJgn4IbitVvt2vFy2KjINQJAPhAtDejZ+ZbMDfyPc6JsS/mWFRt9Eoku4A4usE4f2loEOoeKQ==
 
 is-callable@^1.1.3, is-callable@^1.1.4:
   version "1.1.4"


### PR DESCRIPTION
- The following top-level dependencies were not used in practice, and have been removed:
  - `clone`
  - `intersect-objects`
  - `obs-store`
- The follow top-level dependency was only used in tests, and has been moved dev dependencies:
  - `fast-deep-equal`