### PR TITLE
Add hasPermissions methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 .python-version
 *.log
 .nyc_output
+coverage

--- a/.nycrc
+++ b/.nycrc
@@ -1,4 +1,0 @@
-{
-  "extends": "@istanbuljs/nyc-config-typescript",
-  "all": true
-}

--- a/index.ts
+++ b/index.ts
@@ -351,7 +351,7 @@ export class CapabilitiesController extends BaseController<any, any> implements 
    * @returns Whether the given domain has any permissions.
    */
   hasPermissions (domain: string): boolean {
-    return Boolean(this.state.domains[domain]);
+    return Boolean(this.state.domains?.[domain]);
   }
 
   /**

--- a/index.ts
+++ b/index.ts
@@ -310,6 +310,12 @@ export class CapabilitiesController extends BaseController<any, any> implements 
     return engine;
   }
 
+  /**
+   * Checks the permissions for the given domain, or an empty array.
+   *
+   * @param domain - The domain whose permissions to retrieve.
+   * @returns The permissions for the domain.
+   */
   getPermissionsForDomain (domain: string): IOcapLdCapability[] {
     const { domains = {} } = this.state;
     if (domains[domain]) {
@@ -324,17 +330,41 @@ export class CapabilitiesController extends BaseController<any, any> implements 
    * Follows the delegation chain of the first matching permission found.
    *
    * @param {string} domain - The domain whose permission to retrieve.
-   * @param {string} method - The method
+   * @param {string} method - The method of the permission to retrieve.
    */
   getPermission (domain: string, method: string): IOcapLdCapability | undefined {
-    const permissions = this.getPermissionsForDomain(domain).filter(p => {
-      return p.parentCapability === method;
-    });
+    const permissions = this.getPermissionsForDomain(domain)
+      .filter(permission => {
+        return permission.parentCapability === method;
+      });
     if (permissions.length > 0) {
       return permissions.shift();
     }
 
     return undefined;
+  }
+
+  /**
+   * Checks whether the given domain has permissions.
+   *
+   * @param domain - The domain to check.
+   * @returns Whether the given domain has any permissions.
+   */
+  hasPermissions (domain: string): boolean {
+    return Boolean(this.state.domains[domain]);
+  }
+
+  /**
+   * Checks whether the given domain has the given permission.
+   *
+   * @param domain - The domain to check.
+   * @param method - The method of the permission to check for.
+   * @returns Whether the given domain has the given permission.
+   */
+  hasPermission (domain: string, method: string): boolean {
+    return this.getPermissionsForDomain(domain).some(permission => {
+      return permission.parentCapability === method;
+    });
   }
 
   /**

--- a/nyc.config.js
+++ b/nyc.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: '@istanbuljs/nyc-config-typescript',
+};

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint:fix": "eslint --ext .ts,.js --fix .",
     "prepublishOnly": "yarn build",
     "test": "yarn build:typescript && node test",
-    "test:coverage": "nyc node test"
+    "coverage": "nyc node test",
+    "coverage:html": "nyc --reporter=html node test"
   },
   "keywords": [],
   "author": "",
@@ -29,11 +30,12 @@
     "@types/uuid": "^3.4.4",
     "@typescript-eslint/eslint-plugin": "^2.17.0",
     "@typescript-eslint/parser": "^2.17.0",
+    "clone": "^2.1.2",
     "eslint": "^6.8.0",
     "fast-deep-equal": "^2.0.1",
     "nyc": "^15.0.0",
     "tape": "^4.9.2",
-    "typescript": "^4.0.3"
+    "typescript": "^4.1.2"
   },
   "dependencies": {
     "@metamask/controllers": "^5.0.0",

--- a/test/caveats.js
+++ b/test/caveats.js
@@ -1,8 +1,8 @@
 // / <reference path="../index.ts" />
 
 const test = require('tape');
-const CapabilitiesController = require('../dist').CapabilitiesController;
-const sendRpcMethodWithResponse = require('./lib/utils').sendRpcMethodWithResponse;
+const { CapabilitiesController } = require('../dist');
+const { sendRpcMethodWithResponse } = require('./lib/utils');
 
 const UNAUTHORIZED_CODE = require('eth-rpc-errors').ERROR_CODES.provider.unauthorized;
 

--- a/test/dependentPermissions.js
+++ b/test/dependentPermissions.js
@@ -1,5 +1,5 @@
 const test = require('tape');
-const CapabilitiesController = require('../dist').CapabilitiesController;
+const { CapabilitiesController } = require('../dist');
 const JsonRpcEngine = require('json-rpc-engine');
 
 test('restricted permission gets restricted provider', async (t) => {

--- a/test/forwarding.js
+++ b/test/forwarding.js
@@ -1,5 +1,5 @@
 const test = require('tape');
-const CapabilitiesController = require('../dist').CapabilitiesController;
+const { CapabilitiesController } = require('../dist');
 
 const UNAUTHORIZED_CODE = require('eth-rpc-errors').ERROR_CODES.provider.unauthorized;
 const METHOD_NOT_FOUND_CODE = require('eth-rpc-errors').ERROR_CODES.rpc.methodNotFound;

--- a/test/getPermissions.js
+++ b/test/getPermissions.js
@@ -1,5 +1,5 @@
 const test = require('tape');
-const CapabilitiesController = require('../dist').CapabilitiesController;
+const { CapabilitiesController } = require('../dist');
 const equal = require('fast-deep-equal');
 
 function noop () {}

--- a/test/hasPermissions.js
+++ b/test/hasPermissions.js
@@ -1,0 +1,118 @@
+const test = require('tape');
+const { CapabilitiesController } = require('../dist');
+const clone = require('clone');
+
+function noop () {}
+
+const domain1 = 'foo.com';
+const domain2 = 'bar.io';
+
+const method1 = 'restricted';
+const method2 = 'restricted2';
+
+const domains = {
+  [domain1]: {
+    permissions: [
+      {
+        parentCapability: method1,
+        id: 'abc',
+      },
+    ],
+  },
+  [domain2]: {
+    permissions: [
+      {
+        parentCapability: method2,
+        id: 'xyz',
+      },
+    ],
+  },
+};
+
+test('hasPermissions returns false if no permissions', (t) => {
+  const ctrl = new CapabilitiesController({
+    requestUserApproval: noop,
+  });
+
+  t.equal(ctrl.hasPermissions(domain1), false, 'should return false');
+  t.end();
+});
+
+test('hasPermission returns false if no permissions', (t) => {
+  const ctrl = new CapabilitiesController({
+    requestUserApproval: noop,
+  });
+
+  t.equal(ctrl.hasPermissions(domain1, method1), false, 'should return false');
+  t.end();
+});
+
+test('hasPermissions returns true with permissions', (t) => {
+  const ctrl = new CapabilitiesController({
+    requestUserApproval: noop,
+  },
+  {
+    domains: clone(domains),
+  });
+
+  t.equal(ctrl.hasPermissions(domain1), true, 'should return true for domain1');
+  t.equal(ctrl.hasPermissions(domain2), true, 'should return true for domain2');
+  t.end();
+});
+
+test('hasPermission returns true with permissions and correct method', (t) => {
+  const ctrl = new CapabilitiesController({
+    requestUserApproval: noop,
+  },
+  {
+    domains: clone(domains),
+  });
+
+  t.equal(
+    ctrl.hasPermission(domain1, method1),
+    true,
+    'should return true for domain1 and method1'
+  );
+  t.equal(
+    ctrl.hasPermission(domain2, method2),
+    true,
+    'should return true for domain2 and method2'
+  );
+  t.end();
+});
+
+test('hasPermissions returns with permissions but wrong domain', (t) => {
+  const ctrl = new CapabilitiesController({
+    requestUserApproval: noop,
+  },
+  {
+    domains: {
+      [domain1]: clone(domains[domain1]),
+    },
+  });
+
+  t.equal(ctrl.hasPermissions(domain1), true, 'should return true for domain1');
+  t.equal(ctrl.hasPermissions(domain2), false, 'should return false for domain2');
+  t.end();
+});
+
+test('hasPermission returns false with permissions but wrong method', (t) => {
+  const ctrl = new CapabilitiesController({
+    requestUserApproval: noop,
+  },
+  {
+    domains: clone(domains),
+  });
+
+  t.equal(
+    ctrl.hasPermission(domain1, method2),
+    false,
+    'should return false for domain1 and method2'
+  );
+  t.equal(
+    ctrl.hasPermission(domain2, method1),
+    false,
+    'should return false for domain2 and method1'
+  );
+  t.end();
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,6 @@
 require('./forwarding');
 require('./getPermissions');
+require('./hasPermissions');
 require('./requestPermissions');
 require('./caveats');
 require('./wildcardPermissions');

--- a/test/requestPermissions.js
+++ b/test/requestPermissions.js
@@ -1,5 +1,5 @@
 const test = require('tape');
-const CapabilitiesController = require('../dist').CapabilitiesController;
+const { CapabilitiesController } = require('../dist');
 const equal = require('fast-deep-equal');
 const rpcErrors = require('eth-rpc-errors');
 

--- a/test/wildcardPermissions.js
+++ b/test/wildcardPermissions.js
@@ -1,5 +1,5 @@
 const test = require('tape');
-const CapabilitiesController = require('../dist').CapabilitiesController;
+const { CapabilitiesController } = require('../dist');
 
 const UNAUTHORIZED_CODE = require('eth-rpc-errors').ERROR_CODES.provider.unauthorized;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -729,7 +729,7 @@ cliui@^6.0.0:
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
 
-clone@^2.0.0, clone@^2.1.1:
+clone@^2.0.0, clone@^2.1.1, clone@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
   integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
@@ -3482,10 +3482,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
-  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
+typescript@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.2.tgz#6369ef22516fe5e10304aae5a5c4862db55380e9"
+  integrity sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==
 
 unorm@^1.3.3:
   version "1.6.0"


### PR DESCRIPTION
Adds `hasPermission` and `hasPermissions`. These will enable low-hanging performance enhancements when all you want to know is whether a domain has any or a particular permission.

Also adds tests. As part of adding the tests the following updates were made:
- The `clone` dev dependency was added
- TypeScript was updated (minor version bump)
- Update coverage scripts and coverage config
- Fixed some outdated syntax in tests