### PR TITLE
feat: add filterResponse deep compare with fast-deep-equal

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
     "@typescript-eslint/eslint-plugin": "^2.17.0",
     "@typescript-eslint/parser": "^2.17.0",
     "eslint": "^6.8.0",
-    "fast-deep-equal": "^2.0.1",
     "nyc": "^15.0.0",
     "tape": "^4.9.2",
     "typescript": "^4.0.3"
   },
   "dependencies": {
+    "fast-deep-equal": "^2.0.1",
     "@metamask/controllers": "^3.1.0",
     "eth-rpc-errors": "^3.0.0",
     "is-subset": "^0.1.1",

--- a/src/caveats.ts
+++ b/src/caveats.ts
@@ -2,6 +2,7 @@ import { JsonRpcMiddleware } from 'json-rpc-engine';
 import { IOcapLdCaveat } from './@types/ocap-ld';
 import { unauthorized } from './errors';
 import isSubset from 'is-subset';
+import equal from 'fast-deep-equal';
 
 export type ICaveatFunction = JsonRpcMiddleware;
 
@@ -25,7 +26,7 @@ export const requireParams: ICaveatFunctionGenerator = function requireParams (s
 };
 
 /*
- * Filters array results shallowly.
+ * Filters array results.
  */
 export const filterResponse: ICaveatFunctionGenerator = function filterResponse (serialized: IOcapLdCaveat) {
   const { value } = serialized;
@@ -34,7 +35,10 @@ export const filterResponse: ICaveatFunctionGenerator = function filterResponse 
     next((done) => {
       if (Array.isArray(res.result)) {
         res.result = res.result.filter((item) => {
-          return value.includes(item);
+          const findResult = value.find((v: any) => {
+            return equal(v, item);
+          });
+          return findResult !== undefined;
         });
       }
       done();


### PR DESCRIPTION
This change extends the current `filterResponse` caveat to support not just shallow arrays of strings, but deep compare of objects as well.

rel #119