### PR TITLE
Caveat update

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Currently all supported caveats can be found in the [Caveats.ts file](./src/cave
 
 Right now the supported caveat types are simple, to demonstrate the concept:
 
-- requireParams: Ensures that the method can only be called with a superset of some hard-defined parameters.
+- requireParamsIsSubset: Ensures that the method can only be called with a superset of some hard-defined parameters.
 - filterResponse: Ensures that the response will only include explicitly permitted values in it (if an array).
 - limitResponse: Ensures that the response will only include a maximum number of entries as defined by the value (if an array).
 - forceParams: Overwrites the params of all calls to the method with a specified list of params.
@@ -184,7 +184,7 @@ engine.handle({
       sendEmail: {
         caveats: [
           {
-            type: 'requireParams',
+            type: 'requireParamsIsSubset',
             value: {
               to: 'only@my-address.com',
             }

--- a/src/caveats.ts
+++ b/src/caveats.ts
@@ -8,10 +8,24 @@ export type ICaveatFunction = JsonRpcMiddleware;
 
 export type ICaveatFunctionGenerator = (caveat: IOcapLdCaveat) => ICaveatFunction;
 
+export enum CaveatTypes {
+  filterResponse = 'filterResponse',
+  forceParams = 'forceParams',
+  limitResponseLength = 'limitResponseLength',
+  requireParams = 'requireParams',
+}
+
+export const caveatFunctions = {
+  filterResponse,
+  forceParams,
+  limitResponseLength,
+  requireParams,
+};
+
 /*
  * Require that the request params match those specified by the caveat value.
  */
-export const requireParams: ICaveatFunctionGenerator = function requireParams (serialized: IOcapLdCaveat) {
+export function requireParams (serialized: IOcapLdCaveat): ICaveatFunction {
   const { value } = serialized;
   return (req, res, next, end): void => {
     const permitted = isSubset(req.params, value);
@@ -23,12 +37,12 @@ export const requireParams: ICaveatFunctionGenerator = function requireParams (s
 
     next();
   };
-};
+}
 
 /*
  * Filters array results deeply.
  */
-export const filterResponse: ICaveatFunctionGenerator = function filterResponse (serialized: IOcapLdCaveat) {
+export function filterResponse (serialized: IOcapLdCaveat): ICaveatFunction {
   const { value } = serialized;
   return (_req, res, next, _end): void => {
 
@@ -44,12 +58,12 @@ export const filterResponse: ICaveatFunctionGenerator = function filterResponse 
       done();
     });
   };
-};
+}
 
 /*
  * Limits array results to a specific integer length.
  */
-export const limitResponseLength: ICaveatFunctionGenerator = function limitResponseLength (serialized: IOcapLdCaveat) {
+export function limitResponseLength (serialized: IOcapLdCaveat): ICaveatFunction {
   const { value } = serialized;
   return (_req, res, next, _end): void => {
 
@@ -60,15 +74,15 @@ export const limitResponseLength: ICaveatFunctionGenerator = function limitRespo
       done();
     });
   };
-};
+}
 
 /*
  * Forces the method to be called with given params.
  */
-export const forceParams: ICaveatFunctionGenerator = function forceParams (serialized: IOcapLdCaveat) {
+export function forceParams (serialized: IOcapLdCaveat): ICaveatFunction {
   const { value } = serialized;
   return (req, _, next): void => {
     req.params = [ ...value ];
     next();
   };
-};
+}

--- a/src/caveats.ts
+++ b/src/caveats.ts
@@ -12,20 +12,20 @@ export enum CaveatTypes {
   filterResponse = 'filterResponse',
   forceParams = 'forceParams',
   limitResponseLength = 'limitResponseLength',
-  requireParams = 'requireParams',
+  requireParamsIsSubset = 'requireParamsIsSubset',
 }
 
 export const caveatFunctions = {
   filterResponse,
   forceParams,
   limitResponseLength,
-  requireParams,
+  requireParamsIsSubset,
 };
 
 /*
- * Require that the request params match those specified by the caveat value.
+ * Require that the request params are a subset of the caveat value.
  */
-export function requireParams (serialized: IOcapLdCaveat): ICaveatFunction {
+export function requireParamsIsSubset (serialized: IOcapLdCaveat): ICaveatFunction {
   const { value } = serialized;
   return (req, res, next, end): void => {
     const permitted = isSubset(req.params, value);
@@ -82,7 +82,7 @@ export function limitResponseLength (serialized: IOcapLdCaveat): ICaveatFunction
 export function forceParams (serialized: IOcapLdCaveat): ICaveatFunction {
   const { value } = serialized;
   return (req, _, next): void => {
-    req.params = [ ...value ];
+    req.params = Array.isArray(value) ? [ ...value ] : { ...value };
     next();
   };
 }

--- a/test/caveats.js
+++ b/test/caveats.js
@@ -937,6 +937,26 @@ test('addCaveatFor', async (t) => {
       t.end();
     });
 
+    test('addCaveatFor throws on adding non-existing type', async (t) => {
+
+      try {
+
+        ctrl.addCaveatFor(
+          domain.origin, 'testMethod', {
+            type: 'NON_EXISTING_TYPE',
+            value: [0, 1],
+            name: 'NOT_PREVIOUSLY_ADDED',
+          }
+        );
+
+        t.notOk(true, 'should have thrown');
+
+      } catch (err) {
+        t.ok(err, 'did throw');
+      }
+      t.end();
+    });
+
     test('final state after multiple addCaveatFor calls', async (t) => {
 
       try {

--- a/test/caveats.js
+++ b/test/caveats.js
@@ -6,7 +6,7 @@ const { sendRpcMethodWithResponse } = require('./lib/utils');
 
 const UNAUTHORIZED_CODE = require('eth-rpc-errors').ERROR_CODES.provider.unauthorized;
 
-test('requireParams caveat throws if caveat value is not a subset of params.', async (t) => {
+test('requireParamsIsSubset caveat throws if caveat value is not a subset of params.', async (t) => {
   const domain = { origin: 'www.metamask.io' };
 
   const ctrl = new CapabilitiesController({
@@ -25,7 +25,7 @@ test('requireParams caveat throws if caveat value is not a subset of params.', a
     requestUserApproval: async (permissionsRequest) => {
       const perms = permissionsRequest.permissions;
       perms.write.caveats = [
-        { type: 'requireParams', value: ['foo', { bar: 'baz' }] },
+        { type: 'requireParamsIsSubset', value: ['foo', { bar: 'baz' }] },
       ];
       return perms;
     },
@@ -65,7 +65,7 @@ test('requireParams caveat throws if caveat value is not a subset of params.', a
   t.end();
 });
 
-test('requireParams caveat passes through if caveat value is a subset of params.', async (t) => {
+test('requireParamsIsSubset caveat passes through if caveat value is a subset of params.', async (t) => {
   const domain = { origin: 'www.metamask.io' };
   const params = [
     'foo',
@@ -87,7 +87,7 @@ test('requireParams caveat passes through if caveat value is a subset of params.
     requestUserApproval: async (permissionsRequest) => {
       const perms = permissionsRequest.permissions;
       perms.write.caveats = [
-        { type: 'requireParams', value: ['foo', { bar: 'baz' }] },
+        { type: 'requireParamsIsSubset', value: ['foo', { bar: 'baz' }] },
       ];
       return perms;
     },


### PR DESCRIPTION
- Export `CaveatTypes` enum
- Simplify and refactor caveat validation
  - Previously, we did not check that the caveat type was supported. Now we do. A test case has been added.
- Rename `requireParams` caveat to `requireParamsIsSubset`
  - To better reflect the action of the caveat, which is to reject the request if the params aren't a subset of the caveat value.

-----

_P.S._ My apologies to posterity for the awful commit name.