### PR TITLE
Add params subset caveat, fix name of superset caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ Currently all supported caveats can be found in the [Caveats.ts file](./src/cave
 
 Right now the supported caveat types are simple, to demonstrate the concept:
 
-- requireParamsIsSuperset: Ensures that the method can only be called with a superset of some hard-defined parameters.
+- requireParamsIsSubset: Ensures that the method can only be called with a subset of some predefined parameters.
+- requireParamsIsSuperset: Ensures that the method can only be called with a superset of some predefined parameters.
 - filterResponse: Ensures that the response will only include explicitly permitted values in it (if an array).
 - limitResponse: Ensures that the response will only include a maximum number of entries as defined by the value (if an array).
 - forceParams: Overwrites the params of all calls to the method with a specified list of params.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Currently all supported caveats can be found in the [Caveats.ts file](./src/cave
 
 Right now the supported caveat types are simple, to demonstrate the concept:
 
-- requireParamsIsSubset: Ensures that the method can only be called with a superset of some hard-defined parameters.
+- requireParamsIsSuperset: Ensures that the method can only be called with a superset of some hard-defined parameters.
 - filterResponse: Ensures that the response will only include explicitly permitted values in it (if an array).
 - limitResponse: Ensures that the response will only include a maximum number of entries as defined by the value (if an array).
 - forceParams: Overwrites the params of all calls to the method with a specified list of params.
@@ -184,7 +184,7 @@ engine.handle({
       sendEmail: {
         caveats: [
           {
-            type: 'requireParamsIsSubset',
+            type: 'requireParamsIsSuperset',
             value: {
               to: 'only@my-address.com',
             }

--- a/src/caveats.ts
+++ b/src/caveats.ts
@@ -8,34 +8,50 @@ export type ICaveatFunction = JsonRpcMiddleware;
 
 export type ICaveatFunctionGenerator = (caveat: IOcapLdCaveat) => ICaveatFunction;
 
-export enum CaveatTypes {
-  filterResponse = 'filterResponse',
-  forceParams = 'forceParams',
-  limitResponseLength = 'limitResponseLength',
-  requireParamsIsSubset = 'requireParamsIsSubset',
-}
-
 export const caveatFunctions = {
   filterResponse,
   forceParams,
   limitResponseLength,
   requireParamsIsSubset,
+  requireParamsIsSuperset,
 };
 
-/*
- * Require that the request params are a subset of the caveat value.
+export const CaveatTypes = Object.keys(caveatFunctions).reduce((map, name) => {
+  map[name] = name;
+  return map;
+}, {} as Record<string, string>);
+
+/**
+ * Require that request.params is a subset of or equal to the caveat value.
+ * Arrays are order-dependent, objects are order-independent.
  */
 export function requireParamsIsSubset (serialized: IOcapLdCaveat): ICaveatFunction {
   const { value } = serialized;
   return (req, res, next, end): void => {
-    const permitted = isSubset(req.params, value);
-
-    if (!permitted) {
+    // Check that the caveat value is a superset of or equal to the params
+    if (!isSubset(value, req.params)) {
       res.error = unauthorized({ data: req });
       return end(res.error);
     }
 
-    next();
+    return next();
+  };
+}
+
+/**
+ * Require that request.params is a superset of or equal to the caveat value.
+ * Arrays are order-dependent, objects are order-independent.
+ */
+export function requireParamsIsSuperset (serialized: IOcapLdCaveat): ICaveatFunction {
+  const { value } = serialized;
+  return (req, res, next, end): void => {
+    // Check that the caveat value is a subset of or equal to the params
+    if (!isSubset(req.params, value)) {
+      res.error = unauthorized({ data: req });
+      return end(res.error);
+    }
+
+    return next();
   };
 }
 

--- a/src/caveats.ts
+++ b/src/caveats.ts
@@ -28,7 +28,7 @@ export const CaveatTypes = Object.keys(caveatFunctions).reduce((map, name) => {
 export function requireParamsIsSubset (serialized: IOcapLdCaveat): ICaveatFunction {
   const { value } = serialized;
   return (req, res, next, end): void => {
-    // Check that the caveat value is a superset of or equal to the params
+    // Ensure that the params are a subset of or equal to the caveat value
     if (!isSubset(value, req.params)) {
       res.error = unauthorized({ data: req });
       return end(res.error);
@@ -45,7 +45,7 @@ export function requireParamsIsSubset (serialized: IOcapLdCaveat): ICaveatFuncti
 export function requireParamsIsSuperset (serialized: IOcapLdCaveat): ICaveatFunction {
   const { value } = serialized;
   return (req, res, next, end): void => {
-    // Check that the caveat value is a subset of or equal to the params
+    // Ensure that the params are a superset of or equal to the caveat value
     if (!isSubset(req.params, value)) {
       res.error = unauthorized({ data: req });
       return end(res.error);


### PR DESCRIPTION
After merging #127, I realized that I repeated the same mistake I made in #61, which was reverted in #64.

The caveat formerly known as `requireParams` enforces that the request parameters are a _superset_ of the caveat value, and that is the intended behavior. That is clearly very confusing for me, so that caveat is now renamed to `requireParamsIsSuperset`.

This PR reverts the renaming of the superset caveat done in #127, and creates a new `requireParamsIsSubset` caveat, that actually requires that the request parameters are a subset of the caveat value.

Tests have been added.